### PR TITLE
added support for NODE_OPTIONS

### DIFF
--- a/src/esmockLoader.mjs
+++ b/src/esmockLoader.mjs
@@ -4,8 +4,15 @@ import url from 'url';
 
 import esmock from './esmock.js';
 
-global.esmockloader = global.esmockloader || process.execArgv.some(args => (
-  args.startsWith('--loader=') && args.includes('esmock')));
+global.esmockloader = global.esmockloader || (
+  process.execArgv.some(
+    args => (args.startsWith('--loader=') && args.includes('esmock'))
+  )
+) || (
+  /--(experimental-)?loader=(["']*)esmock\1(?:\s+\S*)?$/.test(
+    process.env.NODE_OPTIONS
+  )
+);
 
 export default esmock;
 


### PR DESCRIPTION
Fixes #52

Tested locally using:

```
git clean -dxf
npm i
npm run test-ava
npm run test-uvu
npm run lint
```

All of the above were repeated for each of the following versions of `node`:

 - [x] Node v14.120.0
 - [x] Node v15.14.0
 - [x] Node v16.16.0 _**`lts`**_
 - [x] Node v17.9.1
 - [ ] Node v18.6.0 _**`latest`**_ (see #53)

Also tested the option locally in various scenarios, including by running:
```
NODE_OPTIONS="--loader=esmock" npx ava ./spec/ava/*.spec.js
```