### PR TITLE
Added NPX and ESMock (self) as a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,10 +55,10 @@
     "sinon": "^12.0.1"
   },
   "scripts": {
-    "test-ava": "ava --node-arguments=\"--loader=./src/esmockLoader.mjs\" ./spec/ava/*.spec.js",
+    "test-ava": "npx ava --node-arguments=\"--loader=./src/esmockLoader.mjs\" ./spec/ava/*.spec.js",
     "test-uvu": "node --no-warnings --loader=./src/esmockLoader.mjs ./node_modules/uvu/bin.js ./spec/uvu/",
     "test": "npm run test-ava && npm run test-uvu",
-    "test-no-warn": "ava --node-arguments=\"--loader=./src/esmockLoader.mjs --no-warnings\"",
-    "lint": "eslint src/*js spec"
+    "test-no-warn": "npx ava --node-arguments=\"--loader=./src/esmockLoader.mjs --no-warnings\"",
+    "lint": "npx eslint src/*js spec"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,14 +51,15 @@
     "uvu": "0.5.3",
     "ava": "^4.0.1",
     "eslint": "^8.12.0",
+    "esmock": "file:.",
     "form-urlencoded": "4.2.1",
     "sinon": "^12.0.1"
   },
   "scripts": {
-    "test-ava": "npx ava --node-arguments=\"--loader=./src/esmockLoader.mjs\" ./spec/ava/*.spec.js",
-    "test-uvu": "node --no-warnings --loader=./src/esmockLoader.mjs ./node_modules/uvu/bin.js ./spec/uvu/",
+    "test-ava": "npx ava --node-arguments=\"--loader=esmock\" ./spec/ava/*.spec.js",
+    "test-uvu": "node --no-warnings --loader=esmock ./node_modules/uvu/bin.js ./spec/uvu/",
     "test": "npm run test-ava && npm run test-uvu",
-    "test-no-warn": "npx ava --node-arguments=\"--loader=./src/esmockLoader.mjs --no-warnings\"",
+    "test-no-warn": "npx ava --node-arguments=\"--loader=esmock --no-warnings\"",
     "lint": "npx eslint src/*js spec"
   }
 }


### PR DESCRIPTION
I'm not sure if these changes are desired at all. If they're not, feel free to close!

### 1. :heavy_check_mark: I updated `"scripts"` in the `package.json` to use [`npx`](https://docs.npmjs.com/cli/v8/commands/npx)

The main justification for this was that I didn't have `ava`, `uvu`, or `eslint` manually installed globally. I added `npx`, since it leverages the executables that are installed in the project's local `node_modules`.

### 2. :heavy_check_mark: I added `esmock` to `devDependencies`

This allows us to specify `--loader` as `esmock`, rather than linking directly to the loader file. This better simulates a real-world use-case with our tests.

### 3. :x: Consider adding `package-lock.json` to the repo

```diff
+ It is highly recommended you commit the generated package lock to
+ source control: this will allow anyone else on your team, your
+ deployments, your CI/continuous integration, and anyone else who
+ runs npm install in your package source to get the exact same
+ dependency tree that you were developing on.

  Additionally, the diffs from these changes are human-readable
  and will inform you of any changes npm has made to your
  node_modules, so you can notice if any transitive dependencies
  were updated, hoisted, etc.
```

If you'd like, I can remove it from the `.gitignore` and add it to the repo in this PR! :slightly_smiling_face: 


## Thoroughly tested

Tested locally using:

```
git clean -dxf
npm i
npm run test-ava
npm run test-uvu
npm run lint
```

All of the above were repeated for each of the following versions of `node`:

 - [x] Node v14.120.0
 - [x] Node v15.14.0
 - [x] Node v16.16.0 _**`lts`**_
 - [x] Node v17.9.1
 - [ ] Node v18.6.0 _**`latest`**_ (see #53)
