### PR TITLE
Fixes extra scenario for NODE_OPTIONS 

### DIFF
--- a/src/esmockLoader.mjs
+++ b/src/esmockLoader.mjs
@@ -9,7 +9,7 @@ global.esmockloader = global.esmockloader || (
     args => (args.startsWith('--loader=') && args.includes('esmock'))
   )
 ) || (
-  /--(experimental-)?loader=(["']*)esmock\1(?:\s+\S*)?$/.test(
+  /(?:^|\s)?--(?:experimental-)?loader=(["']*)esmock\1(?:\s|$)/.test(
     process.env.NODE_OPTIONS
   )
 );


### PR DESCRIPTION
Looks like I left out a scenario where `--loader=esmock` isn't the first argument provided :grimacing:

This new regexp basically just checks to see if the `--loader` option is surrounding by spaces or the start or end of the string.

------

Tested locally using:

```
git clean -dxf
npm i
npm run test-ava
npm run test-uvu
npm run lint
```

All of the above were repeated for each of the following versions of `node`:

 - [x] Node v14.120.0
 - [x] Node v15.14.0
 - [x] Node v16.16.0 _**`lts`**_
 - [x] Node v17.9.1

Also tested the option locally in various scenarios, including by running:
```
NODE_OPTIONS="--loader=esmock" npx ava ./spec/ava/*.spec.js
```