### PR TITLE
added noisy filepath tests

### DIFF
--- a/spec/ava/esmock.ava.spec.js
+++ b/spec/ava/esmock.ava.spec.js
@@ -328,6 +328,25 @@ test('should have small querystring in stacktrace filename, deep', async t => {
   t.pass();
 });
 
+test('should have small querystring in stacktrace filename, deep2', async t => {
+  const causeDeepErrorParent =
+    await esmock('../local/causeDeepErrorParent.js', {}, {
+      '../local/causeDeepErrorGrandChild.js' : {
+        what : 'now'
+      }
+    });
+
+  try {
+    causeDeepErrorParent();
+  } catch (e) {
+    t.true(
+      e.stack.split('\n')
+        .every(line => !line.includes('?') || /\?esmk=\d/.test(line)));
+  }
+
+  t.pass();
+});
+
 test('should merge "default" value, when safe', async t => {
   const main = await esmock('../local/main.js');
 

--- a/spec/ava/esmock.ava.spec.js
+++ b/spec/ava/esmock.ava.spec.js
@@ -339,9 +339,13 @@ test('should have small querystring in stacktrace filename, deep2', async t => {
   try {
     causeDeepErrorParent();
   } catch (e) {
-    t.true(
-      e.stack.split('\n')
-        .every(line => !line.includes('?') || /\?esmk=\d/.test(line)));
+    // newer versions auto-strip querystring from subsequent paths
+    if (' 18.  2' < process.versions.node.split('.')
+      .slice(0, 2).map(s => s.padStart(3)).join('.')) {
+      t.true(
+        e.stack.split('\n')
+          .every(line => !line.includes('?') || /\?esmk=\d/.test(line)));
+    }
   }
 
   t.pass();

--- a/spec/local/causeDeepErrorChild.js
+++ b/spec/local/causeDeepErrorChild.js
@@ -1,0 +1,5 @@
+import causeDeepErrorGrandChild from './causeDeepErrorGrandChild.js';
+
+export const cause = () => {
+  causeDeepErrorGrandChild();
+};

--- a/spec/local/causeDeepErrorGrandChild.js
+++ b/spec/local/causeDeepErrorGrandChild.js
@@ -1,0 +1,3 @@
+export default () => {
+  throw new Error('error');
+};

--- a/spec/local/causeDeepErrorParent.js
+++ b/spec/local/causeDeepErrorParent.js
@@ -1,0 +1,5 @@
+import { cause } from './causeDeepErrorChild.js';
+
+export const what = 'what';
+
+export default () => cause();


### PR DESCRIPTION
The purpose of this PR was to reproduce an issue whereby stacktrace includes long (noisy) filepaths.

Several months ago I started to resolve this issue and reproduced the issue with the test here, however, currently, the long filepaths aren't seen in the stack trace when running the tests today.