### PR TITLE
Introduced realpathSync for symlink resolution

### DIFF
--- a/src/esmockModule.js
+++ b/src/esmockModule.js
@@ -23,6 +23,8 @@ const pathAddProtocol = (pathFull, protocol) => {
     protocol = !resolvewith.iscoremodule(pathFull) ? FILE_PROTOCOL : 'node:';
   if (protocol.includes(FILE_PROTOCOL))
     pathFull = fs.realpathSync.native(pathFull);
+  if (process.platform === 'win32')
+    pathFull = pathFull.split(path.sep).join(path.posix.sep);
   return `${protocol}${pathFull.replace(/^\//, '')}`;
 }
 


### PR DESCRIPTION
Fixes #67

------

Tested locally using [Swivelgames/esmock-issue-67](https://github.com/Swivelgames/esmock-issue-67):

```
cd esmock
git reset --hard HEAD
git clean -dxf
git checkout resolve-symlinks
cd ..
npm run setup:test
npm run --workspace=esmock test-nodeis18
npm run --workspace=esmock test-ava
```

All of the above were repeated for each of the following versions of `node`:

 - [x] Node v16.16.0 _**`lts`**_
 - [x] Node v17.9.1
 - [x] Node v18.6.0 _**`latest`**_

<details><summary>Local test output for all versions (warning: verbose)</summary>

*Command*:
```bash
for i in {16..18}; do \
    n $i && \
    npm run git -- reset --hard HEAD && \
    npm run git -- clean -dxf && \
    npm run git -- checkout resolve-symlinks && \
    npm run setup:test && \
    npm run --workspace=esmock test-nodeis18 && \
    npm run --workspace=esmock test-ava \
    || break; \
done;
```

```py
   installed : v16.16.0 (with npm 8.11.0)

> esmock-ws@1.0.0 git
> npm exec --workspace=esmock -- $(which git) "reset" "--hard" "HEAD"

HEAD is now at e1b93bd introduced realpathSync for symlink resolution

> esmock-ws@1.0.0 git
> npm exec --workspace=esmock -- $(which git) "clean" "-dxf"

Removing spec/local/usesNodeModule.js
/home/jdalrymple/src/by-project/esmock-ws/node_modules/form-urlencoded/form-urlencoded.dist.js
> esmock-ws@1.0.0 git
> npm exec --workspace=esmock -- $(which git) "checkout" "resolve-symlinks"

Already on 'resolve-symlinks'

> esmock-ws@1.0.0 setup:test
> npm run git -- apply ../add-tests.patch


> esmock-ws@1.0.0 git
> npm exec --workspace=esmock -- $(which git) "apply" "../add-tests.patch"


> esmock@1.8.1 test-nodeis18
> if (node -v | grep v18); then npm run test-node18; fi;


> esmock@1.8.1 test-ava
> npx ava --node-arguments="--loader=esmock" ./spec/ava/*.spec.js


(node:1893271) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
(node:1893271) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
  ✔ esmock.ava.only › should not error when esmock used with ava.only
  ✔ esmock.ava › should throw error if !esmockloader
  ✔ esmock.ava › should throw error if local definition file not found (105ms)
  ✔ esmock.ava › should throw error if local file not found (115ms)
  ✔ esmock.ava › should have small querystring in stacktrace filename
  ✔ esmock.ava › should mock a module (170ms)
  ✔ esmock.ava › should mock a node_module (160ms)
  ✔ esmock.ava › should mock core module (154ms)
  ✔ esmock.ava › returns spread-imported [object Module] default export (153ms)
  ✔ esmock.ava › mocks inline `async import("name")` (159ms)
  ✔ esmock.ava › should mock local file (260ms)
  ✔ esmock.ava › should work well with sinon (263ms)
  ✔ esmock.ava › should mock module and local file at the same time (275ms)
  ✔ esmock.ava › __esModule definition, inconsequential (279ms)
  ✔ esmock.ava › should not error when mocked file has space in path (277ms)
  ✔ esmock.ava › should return un-mocked file (368ms)
  ✔ esmock.ava › should return un-mocked file (again) (332ms)
  ✔ esmock.ava › should mock a local file (365ms)
  ✔ esmock.ava › should mock an mjs file (324ms)
  ✔ esmock.ava › should mock an mjs file, again (322ms)
  ✔ esmock.ava › should mock an exported constant values (321ms)
  ✔ esmock.ava › should have small querystring in stacktrace filename, deep (299ms)
  ✔ esmock.ava › should apply third parameter "global" definitions (319ms)
  ✔ esmock.ava › should have small querystring in stacktrace filename, deep2 (302ms)
  ✔ esmock.ava › should mock a module, many times differently (360ms)
  ✔ esmock.ava › should mock a module, globally (364ms)
  ✔ esmock.ava › should purge local and global mocks (363ms)
  ✔ esmock.ava › should merge "default" value, when safe (311ms)
  ─

  28 tests passed
   installed : v17.9.1 (with npm 8.11.0)

> esmock-ws@1.0.0 git
> npm exec --workspace=esmock -- $(which git) "reset" "--hard" "HEAD"

HEAD is now at e1b93bd introduced realpathSync for symlink resolution

> esmock-ws@1.0.0 git
> npm exec --workspace=esmock -- $(which git) "clean" "-dxf"

Removing node_modules/
Removing spec/local/usesNodeModule.js

> esmock-ws@1.0.0 git
> npm exec --workspace=esmock -- $(which git) "checkout" "resolve-symlinks"

Already on 'resolve-symlinks'

> esmock-ws@1.0.0 setup:test
> npm run git -- apply ../add-tests.patch


> esmock-ws@1.0.0 git
> npm exec --workspace=esmock -- $(which git) "apply" "../add-tests.patch"


> esmock@1.8.1 test-nodeis18
> if (node -v | grep v18); then npm run test-node18; fi;


> esmock@1.8.1 test-ava
> npx ava --node-arguments="--loader=esmock" ./spec/ava/*.spec.js


(node:1893498) ExperimentalWarning: Custom ESM Loaders is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
(node:1893498) ExperimentalWarning: Custom ESM Loaders is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
  ✔ esmock.ava › should throw error if !esmockloader
  ✔ esmock.ava › should throw error if local definition file not found
  ✔ esmock.ava › should throw error if local file not found
  ✔ esmock.ava.only › should not error when esmock used with ava.only
  ✔ esmock.ava › should have small querystring in stacktrace filename
  ✔ esmock.ava › should mock a module (143ms)
  ✔ esmock.ava › should mock a node_module (149ms)
  ✔ esmock.ava › should mock core module (146ms)
  ✔ esmock.ava › returns spread-imported [object Module] default export (146ms)
  ✔ esmock.ava › mocks inline `async import("name")` (152ms)
  ✔ esmock.ava › should mock local file (232ms)
  ✔ esmock.ava › should work well with sinon (239ms)
  ✔ esmock.ava › should mock module and local file at the same time (249ms)
  ✔ esmock.ava › __esModule definition, inconsequential (256ms)
  ✔ esmock.ava › should not error when mocked file has space in path (264ms)
  ✔ esmock.ava › should return un-mocked file (316ms)
  ✔ esmock.ava › should return un-mocked file (again) (294ms)
  ✔ esmock.ava › should mock a local file (314ms)
  ✔ esmock.ava › should mock an mjs file (293ms)
  ✔ esmock.ava › should mock an mjs file, again (292ms)
  ✔ esmock.ava › should mock an exported constant values (291ms)
  ✔ esmock.ava › should have small querystring in stacktrace filename, deep (286ms)
  ✔ esmock.ava › should apply third parameter "global" definitions (299ms)
  ✔ esmock.ava › should have small querystring in stacktrace filename, deep2 (291ms)
  ✔ esmock.ava › should mock a module, many times differently (325ms)
  ✔ esmock.ava › should mock a module, globally (327ms)
  ✔ esmock.ava › should purge local and global mocks (327ms)
  ✔ esmock.ava › should merge "default" value, when safe (301ms)
  ─

  28 tests passed
   installed : v18.6.0 (with npm 8.13.2)

> esmock-ws@1.0.0 git
> npm exec --workspace=esmock -- $(which git)

HEAD is now at e1b93bd introduced realpathSync for symlink resolution

> esmock-ws@1.0.0 git
> npm exec --workspace=esmock -- $(which git)

Removing node_modules/
Removing spec/local/usesNodeModule.js

> esmock-ws@1.0.0 git
> npm exec --workspace=esmock -- $(which git)

Already on 'resolve-symlinks'

> esmock-ws@1.0.0 setup:test
> npm run git -- apply ../add-tests.patch


> esmock-ws@1.0.0 git
> npm exec --workspace=esmock -- $(which git)


> esmock@1.8.1 test-nodeis18
> if (node -v | grep v18); then npm run test-node18; fi;

v18.6.0

> esmock@1.8.1 test-node18
> npm run test-node && npm run test-node-ts


> esmock@1.8.1 test-node
> node --no-warnings --loader=esmock --test ./spec/node/

TAP version 13
# Subtest: /home/jdalrymple/src/by-project/esmock-ws/esmock/spec/node/esmock.node.noloader.test.js
ok 1 - /home/jdalrymple/src/by-project/esmock-ws/esmock/spec/node/esmock.node.noloader.test.js
  ---
  duration_ms: 0.229443276
  ...
# Subtest: /home/jdalrymple/src/by-project/esmock-ws/esmock/spec/node/esmock.node.only.test.js
ok 2 - /home/jdalrymple/src/by-project/esmock-ws/esmock/spec/node/esmock.node.only.test.js
  ---
  duration_ms: 0.239113146
  ...
# Subtest: /home/jdalrymple/src/by-project/esmock-ws/esmock/spec/node/esmock.node.test.js
ok 3 - /home/jdalrymple/src/by-project/esmock-ws/esmock/spec/node/esmock.node.test.js
  ---
  duration_ms: 0.680404273
  ...
1..3
# tests 3
# pass 3
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 0.850662641

> esmock@1.8.1 test-node-ts
> node --no-warnings --loader=ts-node/esm --loader=esmock --test ./spec/node-ts/*ts

TAP version 13
# Subtest: /home/jdalrymple/src/by-project/esmock-ws/esmock/spec/node-ts/esmock.node-ts.test.ts
ok 1 - /home/jdalrymple/src/by-project/esmock-ws/esmock/spec/node-ts/esmock.node-ts.test.ts
  ---
  duration_ms: 4.159373018
  ...
1..1
# tests 1
# pass 1
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 4.289176412

> esmock@1.8.1 test-ava
> npx ava --node-arguments="--loader=esmock" ./spec/ava/*.spec.js


(node:1893836) ExperimentalWarning: Custom ESM Loaders is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
(node:1893836) ExperimentalWarning: Custom ESM Loaders is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
  ✔ esmock.ava.only › should not error when esmock used with ava.only
  ✔ esmock.ava › should throw error if !esmockloader
  ✔ esmock.ava › should throw error if local definition file not found
  ✔ esmock.ava › should throw error if local file not found
  ✔ esmock.ava › should have small querystring in stacktrace filename
  ✔ esmock.ava › should mock a module (129ms)
  ✔ esmock.ava › should mock a node_module (134ms)
  ✔ esmock.ava › should mock core module (130ms)
  ✔ esmock.ava › returns spread-imported [object Module] default export (130ms)
  ✔ esmock.ava › mocks inline `async import("name")` (137ms)
  ✔ esmock.ava › should mock local file (220ms)
  ✔ esmock.ava › should work well with sinon (227ms)
  ✔ esmock.ava › should mock module and local file at the same time (238ms)
  ✔ esmock.ava › __esModule definition, inconsequential (245ms)
  ✔ esmock.ava › should not error when mocked file has space in path (284ms)
  ✔ esmock.ava › should return un-mocked file (333ms)
  ✔ esmock.ava › should return un-mocked file (again) (312ms)
  ✔ esmock.ava › should mock a local file (330ms)
  ✔ esmock.ava › should mock an mjs file (312ms)
  ✔ esmock.ava › should mock an mjs file, again (311ms)
  ✔ esmock.ava › should mock an exported constant values (311ms)
  ✔ esmock.ava › should have small querystring in stacktrace filename, deep (310ms)
  ✔ esmock.ava › should apply third parameter "global" definitions (323ms)
  ✔ esmock.ava › should have small querystring in stacktrace filename, deep2 (316ms)
  ✔ esmock.ava › should mock a module, many times differently (346ms)
  ✔ esmock.ava › should mock a module, globally (349ms)
  ✔ esmock.ava › should purge local and global mocks (348ms)
  ✔ esmock.ava › should merge "default" value, when safe (323ms)
  ─

  28 tests passed
```