### PR TITLE
add support for import subpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # changelog
 
- * 1.9.6 _Aug.19.2022_
+ * 1.9.6 _Aug.24.2022_
    * support parent url to facilitate sourcemap usage, [113](https://github.com/iambumblehead/esmock/issues/113)
+   * support import subpaths, eg `import: { '#sub': './path.js' }`
  * 1.9.5 _Aug.19.2022_
    * support cjs packges that define [main relative directory only](https://github.com/iambumblehead/esmock/issues/119)
  * 1.9.4 _Aug.15.2022_

--- a/README.md
+++ b/README.md
@@ -47,11 +47,6 @@ await esmock(
   { ...globalmocks }) // mock definitions imported everywhere
 ```
 
-_note: `esmock` is unable to mock some modules,_ due to missing support for some [package.json export expressions.][20] This area is improving [—see the wiki][20] for details.
-
-[20]: https://github.com/iambumblehead/esmock/wiki#user-content-problems-module-resolution
-
-
 `esmock` examples
 ``` javascript
 import test from 'node:test'

--- a/README.md
+++ b/README.md
@@ -59,15 +59,16 @@ import assert from 'node:assert/strict'
 import esmock from 'esmock'
 
 test('should mock local files and packages', async () => {
-  const main = await esmock('../src/main.js', {
+  const stringy = await esmock('../src/stringy.js', {
     stringifierpackage: JSON.stringify,
+    '#icons': { kasa: '☂' },
     '../src/hello.js': {
       default: () => 'world',
-      exportedFunction: () => 'foo'
+      exportedFunction: () => ({ icon: 'kasa' })
     }
   })
 
-  assert.strictEqual(main(), JSON.stringify({ test: 'world foo' }))
+  assert.strictEqual(stringy(), JSON.stringify({ kasa: 'world ☂' }))
 })
 
 test('should do global instance mocks —third param', async () => {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "rewire"
   ],
   "dependencies": {
-    "resolvewithplus": "iambumblehead/resolvewithplus"
+    "resolvewithplus": "^0.9.0"
   },
   "devDependencies": {
     "c8": "^7.12.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esmock",
   "type": "module",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "license": "ISC",
   "readmeFilename": "README.md",
   "description": "provides native ESM import mocking for unit tests",
@@ -54,7 +54,7 @@
     "rewire"
   ],
   "dependencies": {
-    "resolvewithplus": "^0.8.9"
+    "resolvewithplus": "iambumblehead/resolvewithplus"
   },
   "devDependencies": {
     "c8": "^7.12.0",

--- a/src/esmockLoader.js
+++ b/src/esmockLoader.js
@@ -20,10 +20,10 @@ const isLT1612 = major < 16 || (major === 16 && minor < 12)
 
 const esmockGlobalsAndAfterRe = /\?esmockGlobals=.*/
 const esmockGlobalsAndBeforeRe = /.*\?esmockGlobals=/
-const esmockModuleKeysRe = /#esmockModuleKeys/
+const esmockModuleKeysRe = /#-#esmockModuleKeys/
 const exportNamesRe = /.*exportNames=(.*)/
 const esmockKeyRe = /esmockKey=\d*/
-const withHashRe = /[^#]*#/
+const withHashRe = /.*#-#/
 const isesmRe = /isesm=true/
 
 const resolve = async (specifier, context, nextResolve) => {
@@ -55,7 +55,7 @@ const resolve = async (specifier, context, nextResolve) => {
 
   const resolvedurl = decodeURI(resolved.url)
   const moduleKeyRe = new RegExp(
-    '.*(' + resolvedurl + '\\?' + esmockKeyParam + '[^#]*).*')
+    '.*(' + resolvedurl + '\\?' + esmockKeyParam + '(?:(?!#-#).)*).*')
 
   const [ keyUrl, keys ] = esmockKeyLong.split(esmockModuleKeysRe)
   const moduleGlobals = keyUrl.replace(esmockGlobalsAndBeforeRe, '')
@@ -68,7 +68,7 @@ const resolve = async (specifier, context, nextResolve) => {
   if (moduleKey) {
     resolved.url = isesmRe.test(moduleKey)
       ? moduleKey
-      : urlDummy + '#' + moduleKey
+      : urlDummy + '#-#' + moduleKey
   } else if (moduleGlobals && moduleGlobals !== 'null') {
     if (!resolved.url.startsWith('node:')) {
       resolved.url += '?esmockGlobals=' + moduleGlobals

--- a/src/esmockModule.js
+++ b/src/esmockModule.js
@@ -102,10 +102,10 @@ const esmockModuleImportedSanitize = (importedModule, esmockKey) => {
 const esmockModuleImportedPurge = modulePathKey => {
   const purgeKey = key => key === 'null' || esmockCacheSet(key, null)
   const longKey = esmockKeyGet(modulePathKey.split('esmk=')[1])
-  const [ url, keys ] = longKey.split('#esmockModuleKeys=')
+  const [ url, keys ] = longKey.split('#-#esmockModuleKeys=')
 
-  String(keys).split('#').forEach(purgeKey)
-  String(url.split('esmockGlobals=')[1]).split('#').forEach(purgeKey)
+  String(keys).split('#-#').forEach(purgeKey)
+  String(url.split('esmockGlobals=')[1]).split('#-#').forEach(purgeKey)
 }
 
 const esmockNextKey = ((key = 0) => () => ++key)()
@@ -174,10 +174,10 @@ const esmockModuleMock = async (calleePath, modulePath, defs, gdefs, opt) => {
     throw new Error(`modulePath not found: "${modulePath}"`)
 
   const esmockKeyLong = pathAddProtocol(pathModuleFull, FILE_PROTOCOL) + '?' +
-    'key=:esmockKey?esmockGlobals=:esmockGlobals#esmockModuleKeys=:moduleKeys'
+    'key=:esmockKey?esmockGlobals=:esmockGlobals#-#esmockModuleKeys=:moduleKeys'
       .replace(/:esmockKey/, esmockKey)
-      .replace(/:esmockGlobals/, esmockGlobalKeys.join('#') || 'null')
-      .replace(/:moduleKeys/, esmockModuleKeys.join('#'))
+      .replace(/:esmockGlobals/, esmockGlobalKeys.join('#-#') || 'null')
+      .replace(/:moduleKeys/, esmockModuleKeys.join('#-#'))
 
   esmockKeySet(String(esmockKey), esmockKeyLong)
 

--- a/tests/local/subpath.js
+++ b/tests/local/subpath.js
@@ -1,0 +1,1 @@
+export const subpathfunction = () => 'subpathfunctionval'

--- a/tests/local/subpathimporter.js
+++ b/tests/local/subpathimporter.js
@@ -1,0 +1,3 @@
+import { subpathfunction } from '#sub'
+
+export const subpathfunctionWrap = () => subpathfunction()

--- a/tests/package.json
+++ b/tests/package.json
@@ -10,7 +10,10 @@
   "exports": {
     "types": "./package.json.esmock.export.d.ts",
     "import": "./package.json.esmock.export.js"
-  },  
+  },
+  "imports": {
+    "#sub": "./local/subpath.js"
+  },
   "dependencies": {
     "pg": "^8.7.3",
     "eslint": "^8.12.0",

--- a/tests/tests-node/esmock.node.test.js
+++ b/tests/tests-node/esmock.node.test.js
@@ -1,7 +1,20 @@
+import path from 'path'
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import esmock from '../../src/esmock.js'
 import sinon from 'sinon'
+
+test('should mock a subpath', async () => {
+  const localpackagepath = path.resolve('../local/')
+  const { subpathfunctionWrap } = await esmock(
+    '../local/subpathimporter.js', localpackagepath, {
+      '#sub': {
+        subpathfunction: () => 'subpathMOCK'
+      }
+    })
+
+  assert.strictEqual(subpathfunctionWrap(), 'subpathMOCK')
+})
 
 test('should return un-mocked file', async () => {
   const main = await esmock('../local/main.js')


### PR DESCRIPTION
this PR adds support for import subpaths, so that esmock will be able to mock "#stub" from "import": { "#sub": "./path.js" }