### PR TITLE
mock modules that aren't found, test failing

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [18.6]
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 6
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.6]
         os: [ubuntu-latest, windows-latest]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # changelog
 
+ * 1.9.7 _Aug.25.2022_
+   * support mocking specifiers that [aren't found in filesystem](https://github.com/iambumblehead/esmock/issues/126)
  * 1.9.6 _Aug.24.2022_
    * support parent url to facilitate sourcemap usage, [113](https://github.com/iambumblehead/esmock/issues/113)
    * support import subpaths, eg `import: { '#sub': './path.js' }`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esmock",
   "type": "module",
-  "version": "1.9.6",
+  "version": "1.9.7",
   "license": "ISC",
   "readmeFilename": "README.md",
   "description": "provides native ESM import mocking for unit tests",

--- a/src/esmockDummy.js
+++ b/src/esmockDummy.js
@@ -1,0 +1,3 @@
+// ex, file:///path/to/esmockDummy.js,
+//     file:///c:/path/to/esmockDummy.js
+export default import.meta.url

--- a/src/esmockLoader.js
+++ b/src/esmockLoader.js
@@ -42,10 +42,13 @@ const resolve = async (specifier, context, nextResolve) => {
     ? global.esmockKeyGet(esmockKeyParamSmall.split('=')[1])
     : parentURL
 
-  if (!esmockKeyRe.test(esmockKeyLong))
+  const [ esmockKeyParam ] = String(esmockKeyLong).match(esmockKeyRe) || []
+  if (!esmockKeyParam)
     return nextResolveCall(nextResolve, specifier, context)
+  // if (!esmockKeyRe.test(esmockKeyLong))
+  //   return nextResolveCall(nextResolve, specifier, context)
 
-  const [ esmockKeyParam ] = esmockKeyLong.match(esmockKeyRe)
+  // const [ esmockKeyParam ] = esmockKeyLong.match(esmockKeyRe)
   const [ keyUrl, keys ] = esmockKeyLong.split(esmockModuleKeysRe)
   const moduleGlobals = keyUrl && keyUrl.replace(esmockGlobalsAndBeforeRe, '')
   // do not call 'nextResolve' for notfound modules

--- a/src/esmockLoader.js
+++ b/src/esmockLoader.js
@@ -36,6 +36,12 @@ const resolve = async (specifier, context, nextResolve) => {
   const [ esmockKeyParam ] =
     (esmockKeyLong && esmockKeyLong.match(esmockKeyRe) || [])
 
+  if (esmockKeyLong && esmockKeyLong.includes('file:///vue')) {
+    return {
+      shortCircuit: true,
+      url: urlDummy + '#-#' + 'vue'
+    }
+  }
   // new versions of node: when multiple loaders are used and context
   // is passed to nextResolve, the process crashes in a recursive call
   // see: /esmock/issues/#48
@@ -85,6 +91,11 @@ const load = async (url, context, nextLoad) => {
   url = url.replace(esmockGlobalsAndAfterRe, '')
   if (url.startsWith(urlDummy)) {
     url = url.replace(withHashRe, '')
+  }
+
+  if (url === 'vue') {
+    url = 'file:///vue?esmockKey=1&esmockModuleKey=vue'
+      + '&isesm=false&exportNames=default,h'
   }
 
   const exportedNames = exportNamesRe.test(url) &&

--- a/src/esmockLoader.js
+++ b/src/esmockLoader.js
@@ -1,19 +1,11 @@
 import process from 'process'
-import path from 'path'
-import url from 'url'
-
 import esmock from './esmock.js'
 import esmockIsLoader from './esmockIsLoader.js'
+import urlDummy from './esmockDummy.js'
 
 global.esmockloader = esmockIsLoader
 
 export default esmock
-
-// ex, file:///path/to/esmock,
-//     file:///c:/path/to/esmock
-const urlDummy = 'file:///' + path
-  .join(path.dirname(url.fileURLToPath(import.meta.url)), 'esmock.js')
-  .replace(/^\//, '')
 
 const [ major, minor ] = process.versions.node.split('.').map(it => +it)
 const isLT1612 = major < 16 || (major === 16 && minor < 12)

--- a/src/esmockLoader.js
+++ b/src/esmockLoader.js
@@ -42,13 +42,10 @@ const resolve = async (specifier, context, nextResolve) => {
     ? global.esmockKeyGet(esmockKeyParamSmall.split('=')[1])
     : parentURL
 
-  const [ esmockKeyParam ] = String(esmockKeyLong).match(esmockKeyRe) || []
-  if (!esmockKeyParam)
+  if (!esmockKeyRe.test(esmockKeyLong))
     return nextResolveCall(nextResolve, specifier, context)
-  // if (!esmockKeyRe.test(esmockKeyLong))
-  //   return nextResolveCall(nextResolve, specifier, context)
 
-  // const [ esmockKeyParam ] = esmockKeyLong.match(esmockKeyRe)
+  const [ esmockKeyParam ] = String(esmockKeyLong).match(esmockKeyRe)
   const [ keyUrl, keys ] = esmockKeyLong.split(esmockModuleKeysRe)
   const moduleGlobals = keyUrl && keyUrl.replace(esmockGlobalsAndBeforeRe, '')
   // do not call 'nextResolve' for notfound modules

--- a/src/esmockModule.js
+++ b/src/esmockModule.js
@@ -149,7 +149,7 @@ const esmockModulesCreate = async (pathCallee, pathModule, esmockKey, defs, keys
     throw new Error(`not a valid path: "${keys[0]}" (used by ${pathCallee})`)
   }
 
-  if (process.platform === 'win32')
+  if (mockedPathFull && process.platform === 'win32')
     mockedPathFull = mockedPathFull.split(path.sep).join(path.posix.sep)
 
   mocks.push(await esmockModuleCreate(

--- a/src/esmockModule.js
+++ b/src/esmockModule.js
@@ -123,6 +123,7 @@ const esmockModuleCreate = async (esmockKey, key, mockPathFull, mockDef, opt) =>
     'esmockKey=' + esmockKey,
     'esmockModuleKey=' + key,
     'isesm=' + isesm,
+    opt.isfound ? 'found' : 'notfound=' + key,
     mockExportNames ? 'exportNames=' + mockExportNames : 'exportNone'
   ].join('&')
 
@@ -140,8 +141,7 @@ const esmockModulesCreate = async (pathCallee, pathModule, esmockKey, defs, keys
     return mocks
 
   let mockedPathFull = resolvewith(keys[0], pathCallee)
-      || (opt.isErrorPackageNotFound === false && keys[0])
-  if (!mockedPathFull) {
+  if (!mockedPathFull && opt.isPackageNotFoundError !== false) {
     pathCallee = pathCallee
       .replace(/^\/\//, '')
       .replace(process.cwd(), '.')
@@ -155,9 +155,9 @@ const esmockModulesCreate = async (pathCallee, pathModule, esmockKey, defs, keys
   mocks.push(await esmockModuleCreate(
     esmockKey,
     keys[0],
-    mockedPathFull,
+    mockedPathFull || keys[0],
     defs[keys[0]],
-    opt
+    Object.assign({ isfound: Boolean(mockedPathFull) }, opt)
   ))
 
   return esmockModulesCreate(

--- a/src/esmockModule.js
+++ b/src/esmockModule.js
@@ -12,7 +12,7 @@ import {
 
 const isObj = o => typeof o === 'object' && o
 const isDefaultDefined = o => isObj(o) && 'default' in o
-const isDirPathRe = /^\.?\.?([a-zA-Z]:)?(\/|\\)/;
+const isDirPathRe = /^\.?\.?([a-zA-Z]:)?(\/|\\)/
 const FILE_PROTOCOL = 'file:///'
 
 // https://url.spec.whatwg.org/, eg, file:///C:/demo file:///root/linux/path

--- a/tests/local/notinstalledVueComponent.js
+++ b/tests/local/notinstalledVueComponent.js
@@ -1,0 +1,3 @@
+import {h} from 'vue'
+
+export default () => h('svg', { /* some properties */ })

--- a/tests/tests-ava/spec/esmock.ava.spec.js
+++ b/tests/tests-ava/spec/esmock.ava.spec.js
@@ -2,7 +2,7 @@ import test from 'ava'
 import esmock from 'esmock'
 import sinon from 'sinon'
 
-test('should not error when handling non-extnsible object', async t => {
+test('should not error when handling non-extensible object', async t => {
   // if esmock tries to simulate babel and define default.default
   // runtime error may occur if non-extensible is defined there
   await esmock.px('../../local/importsNonDefaultClass.js', {

--- a/tests/tests-node/esmock.node.test.js
+++ b/tests/tests-node/esmock.node.test.js
@@ -15,7 +15,7 @@ test('should mock package, even when package is not installed', async () => {
 
   assert.strictEqual(component()[0], 'svg')
 })
-/*
+
 test('should mock a subpath', async () => {
   const localpackagepath = path.resolve('../local/')
   const { subpathfunctionWrap } = await esmock(
@@ -421,4 +421,3 @@ test('should strict mock by default, partial mock optional', async () => {
 
   assert.deepEqual(pathWrapPartial.basename('/dog.png'), 'dog.png')
 })
-*/

--- a/tests/tests-node/esmock.node.test.js
+++ b/tests/tests-node/esmock.node.test.js
@@ -5,12 +5,24 @@ import esmock from '../../src/esmock.js'
 import sinon from 'sinon'
 
 test('should mock package, even when package is not installed', async () => {
+  const component = await esmock(`../local/notinstalledVueComponent.js`, {
+    vue: {
+      h: (...args) => args
+    }
+  }, {}, {
+    isPackageNotFoundError: false
+  })
+
+  assert.strictEqual(component()[0], 'svg')
+})
+
+test('should mock package, even when package is not installed', async () => {
   const component = await esmock(`../local/notinstalledVueComponent.js`, {}, {
     vue: {
       h: (...args) => args
     }
   }, {
-    isErrorPackageNotFound: false
+    isPackageNotFoundError: false
   })
 
   assert.strictEqual(component()[0], 'svg')
@@ -421,3 +433,4 @@ test('should strict mock by default, partial mock optional', async () => {
 
   assert.deepEqual(pathWrapPartial.basename('/dog.png'), 'dog.png')
 })
+

--- a/tests/tests-node/esmock.node.test.js
+++ b/tests/tests-node/esmock.node.test.js
@@ -4,6 +4,18 @@ import assert from 'node:assert/strict'
 import esmock from '../../src/esmock.js'
 import sinon from 'sinon'
 
+test('should mock package, even when package is not installed', async () => {
+  const component = await esmock(`../local/notinstalledVueComponent.js`, {}, {
+    vue: {
+      h: (...args) => args
+    }
+  }, {
+    isErrorPackageNotFound: false
+  })
+
+  assert.strictEqual(component()[0], 'svg')
+})
+/*
 test('should mock a subpath', async () => {
   const localpackagepath = path.resolve('../local/')
   const { subpathfunctionWrap } = await esmock(
@@ -409,3 +421,4 @@ test('should strict mock by default, partial mock optional', async () => {
 
   assert.deepEqual(pathWrapPartial.basename('/dog.png'), 'dog.png')
 })
+*/


### PR DESCRIPTION
closes https://github.com/iambumblehead/esmock/issues/126

@cawa-93 when esmock is chained with other "--loader" modules (node v18) each module loader must call `await nextResolve` and this call breaks the loader and this is demonstrated with the failing test here.
```console
      duration_ms: 0.008446949
      failureType: 'testCodeFailure'
      error: "Cannot find package 'vue' imported from /home/bumble/software/esmock/tests/local/notinstalledVueComponent.js"
      code: 'ERR_MODULE_NOT_FOUND'
      stack: |-
        new NodeError (node:internal/errors:387:5)
        packageResolve (node:internal/modules/esm/resolve:909:9)
        moduleResolve (node:internal/modules/esm/resolve:958:20)
        defaultResolve (node:internal/modules/esm/resolve:1173:11)
        nextResolve (node:internal/modules/esm/loader:173:28)
        resolve (file:///home/bumble/software/esmock/src/esmockLoader.js:50:13)
        nextResolve (node:internal/modules/esm/loader:173:28)
        ESMLoader.resolve (node:internal/modules/esm/loader:852:30)
        ESMLoader.getModuleJob (node:internal/modules/esm/loader:439:18)
        ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:76:40)

```

Feel free to try anything out here. I will try and think about more and experiment to try and get around the runtime error.