### PR TITLE
begin updating readme with explanation of strict and partial

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@
 [2]: https://github.com/iambumblehead/esmock "esmock"
 [3]: https://github.com/iambumblehead/esmock/tree/master/tests "tests"
 
-
 `esmock` is used with node's --loader
 ``` json
 {
@@ -47,7 +46,7 @@ await esmock(
   { ...globalmocks }) // mock definitions imported everywhere
 ```
 
-**`esmock` requires one to choose and import a specific variant, either "esmock/strict" or "esmock/partial".** The strict variant gives un-modified mock definitions. The partial variant gives mock definitions that are merged with the original module definitions. Both variants are demonstrated in the last test below,
+**`esmock` requires one to choose and import a specific variant, either "esmock/strict" or "esmock/partial".** The strict variant gives un-modified mock definitions. The partial variant gives mock definitions that are merged with the original module definitions. Both variants are demonstrated in tests below. [See the esmock guide][10] for more details.
 ``` javascript
 import test from 'node:test'
 import assert from 'node:assert/strict'
@@ -92,8 +91,8 @@ test('should mock "await import()" using esmock.p', async () => {
   // a bit more info are found in the wiki guide
 })
 
-// a "partial mock" merges the new and original definitions
 test('should suppport strict and partial mocking', async () => {
+  // a "strict mock" uses the mock definition only
   const pathWrapStrict = await esmockStrict('../src/pathWrap.js', {
     path: { dirname: () => '/home/' }
   })
@@ -104,6 +103,7 @@ test('should suppport strict and partial mocking', async () => {
     message: 'path.basename is not a function'
   })
 
+  // a "partial mock" merges the new and original definitions
   const pathWrapPartial = await esmockPartial('../src/pathWrap.js', {
     path: { dirname: () => '/home/' }
   })

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ await esmock(
   { ...globalmocks }) // mock definitions imported everywhere
 ```
 
-**`esmock` requires one to choose and import a specific variant, either "esmock/strict" or "esmock/partial".** The strict variant gives un-modified mock definitions. The partial variant gives mock definitions that are merged with the original module definitions. Both variants are demonstrated below,
+**`esmock` requires one to choose and import a specific variant, either "esmock/strict" or "esmock/partial".** The strict variant gives un-modified mock definitions. The partial variant gives mock definitions that are merged with the original module definitions. Both variants are demonstrated in the final test below,
 ``` javascript
 import test from 'node:test'
 import assert from 'node:assert/strict'

--- a/README.md
+++ b/README.md
@@ -47,44 +47,13 @@ await esmock(
   { ...globalmocks }) // mock definitions imported everywhere
 ```
 
-
-`esmock` requires one to choose and import a specific variant, either "strict" or "partial". The strict variant gives un-modified mock definitions. The partial variant gives mock definitions that are merged with the original module definitions. Both variants are demonstrated below,
-
-_./dogpath.js_
-``` javascript
-import path from 'path'
-
-export default () => path.join(path.dirname('/path/cat'), 'dog')
-```
-
-_./dogpath.test.js_
-``` javascript
-import test from 'node:test'
-import assert from 'node:assert/strict'
-import esmockStrict from 'esmock/strict'
-import esmockPartial from 'esmock/partial'
-
-test('should suppport strict and partial mocking', async () => {
-  const mocks = { path: { dirname: () => '/image/' } }
-  const dogpathStrict = await esmockStrict('./dogpath.js', mocks)
-  const dogpathPartial = await esmockPartial('./dogpath.js', mocks)
-
-  // error, because path.join was not defined
-  await assert.rejects(async () => dogpathStrict(), {
-    name: 'TypeError',
-    message: 'path.join is not a function'
-  })
-
-  // no error, because "core" path.join was merged into the mock
-  assert.deepEqual(dogpathPartial(), '/image/dog')
-})
-```
-
-`esmock` examples
+**Note, `esmock` requires one to choose and import a specific variant, either "esmock/strict" or "esmock/partial".** The strict variant gives un-modified mock definitions. The partial variant gives mock definitions that are merged with the original module definitions. Both variants are demonstrated below,
 ``` javascript
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import esmock from 'esmock/partial'
+import esmockStrict from 'esmock/strict'
+import esmockPartial from 'esmock/partial'
 
 test('should mock packages and local files', async () => {
   const cookup = await esmock('../src/cookup.js', {
@@ -121,5 +90,26 @@ test('should mock "await import()" using esmock.p', async () => {
   // mock definition is returned from cache, when import is called
   assert.strictEqual(await doAwaitImport('cfg'), 'cfg')
   // a bit more info are found in the wiki guide
+})
+
+// a "partial mock" merges the new and original definitions
+test('should suppport partial mocks', async () => {
+  const pathWrap = await esmockStrict('../src/pathWrap.js', {
+    path: { dirname: () => '/home/' }
+  })
+
+  // an error, because path.basename was not defined
+  await assert.rejects(async () => pathWrap.basename('/dog.png'), {
+    name: 'TypeError',
+    message: 'path.basename is not a function'
+  })
+
+  const pathWrapPartial = await esmockPartial('../src/pathWrap.js', {
+    path: { dirname: () => '/home/' }
+  })
+
+  // no error, because "core" path.basename was merged into the mock
+  assert.deepEqual(pathWrapPartial.basename('/dog.png'), 'dog.png')
+  assert.deepEqual(pathWrapPartial.dirname(), '/home/')
 })
 ```

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ await esmock(
   { ...globalmocks }) // mock definitions imported everywhere
 ```
 
-**`esmock` requires one to choose and import a specific variant, either "esmock/strict" or "esmock/partial".** The strict variant gives un-modified mock definitions. The partial variant gives mock definitions that are merged with the original module definitions. Both variants are demonstrated in the final test below,
+**`esmock` requires one to choose and import a specific variant, either "esmock/strict" or "esmock/partial".** The strict variant gives un-modified mock definitions. The partial variant gives mock definitions that are merged with the original module definitions. Both variants are demonstrated in the last test below,
 ``` javascript
 import test from 'node:test'
 import assert from 'node:assert/strict'

--- a/README.md
+++ b/README.md
@@ -65,12 +65,9 @@ import esmockStrict from 'esmock/strict'
 import esmockPartial from 'esmock/partial'
 
 test('should suppport strict and partial mocking', async () => {
-  const dogpathStrict = await esmockStrict('./dogpath.js', {
-    path: { dirname: () => '/image/' }
-  })
-  const dogpathPartial = await esmockPartial('./dogpath.js', {
-    path: { dirname: () => '/image/' }
-  })
+  const mocks = { path: { dirname: () => '/image/' } }
+  const dogpathStrict = await esmockStrict('./dogpath.js', mocks)
+  const dogpathPartial = await esmockPartial('./dogpath.js', mocks)
 
   // error, because path.join was not defined
   await assert.rejects(async () => dogpathStrict(), {

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ test('should mock "await import()" using esmock.p', async () => {
 })
 
 // a "partial mock" merges the new and original definitions
-test('should suppport partial mocks', async () => {
+test('should suppport strict and partial mocking', async () => {
   const pathWrap = await esmockStrict('../src/pathWrap.js', {
     path: { dirname: () => '/home/' }
   })

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ await esmock(
   { ...globalmocks }) // mock definitions imported everywhere
 ```
 
-**Note, `esmock` requires one to choose and import a specific variant, either "esmock/strict" or "esmock/partial".** The strict variant gives un-modified mock definitions. The partial variant gives mock definitions that are merged with the original module definitions. Both variants are demonstrated below,
+**`esmock` requires one to choose and import a specific variant, either "esmock/strict" or "esmock/partial".** The strict variant gives un-modified mock definitions. The partial variant gives mock definitions that are merged with the original module definitions. Both variants are demonstrated below,
 ``` javascript
 import test from 'node:test'
 import assert from 'node:assert/strict'

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ await esmock(
   { ...globalmocks }) // mock definitions imported everywhere
 ```
 
-**`esmock` requires one to choose and import a specific variant, either "esmock/strict" or "esmock/partial".** The strict variant gives un-modified mock definitions. The partial variant gives mock definitions that are merged with the original module definitions. Both variants are demonstrated in tests below. [See the esmock guide][10] for more details.
+**`esmock` is imported from "esmock/strict" or "esmock/partial".** The strict variant gives un-modified mock definitions. The partial variant gives mock definitions that are merged with the original module definitions. Both variants are demonstrated in tests below. [See the esmock guide][10] for more details.
 ``` javascript
 import test from 'node:test'
 import assert from 'node:assert/strict'

--- a/README.md
+++ b/README.md
@@ -94,12 +94,12 @@ test('should mock "await import()" using esmock.p', async () => {
 
 // a "partial mock" merges the new and original definitions
 test('should suppport strict and partial mocking', async () => {
-  const pathWrap = await esmockStrict('../src/pathWrap.js', {
+  const pathWrapStrict = await esmockStrict('../src/pathWrap.js', {
     path: { dirname: () => '/home/' }
   })
 
   // an error, because path.basename was not defined
-  await assert.rejects(async () => pathWrap.basename('/dog.png'), {
+  await assert.rejects(async () => pathWrapStrict.basename('/dog.png'), {
     name: 'TypeError',
     message: 'path.basename is not a function'
   })

--- a/package.json
+++ b/package.json
@@ -8,8 +8,18 @@
   "author": "chris <chris@bumblehead.com>",
   "main": "./src/esmockLoader.js",
   "exports": {
-    "types": "./src/esmock.d.ts",
-    "import": "./src/esmockLoader.js"
+    ".": {
+      "types": "./src/esmock.d.ts",
+      "import": "./src/esmockLoader.js"
+    },
+    "./strict": {
+      "types": "./src/esmock.d.ts",
+      "import": "./src/esmockStrict.js"
+    },
+    "./partial": {
+      "types": "./src/esmock.d.ts",
+      "import": "./src/esmockPartial.js"
+    }
   },
   "repository": {
     "type": "git",

--- a/src/esmock.js
+++ b/src/esmock.js
@@ -1,4 +1,5 @@
 import esmockIsLoader from './esmockIsLoader.js'
+import esmockArgs from './esmockArgs.js'
 
 import {
   esmockModuleMock,
@@ -10,23 +11,8 @@ import {
   esmockCache
 } from './esmockCache.js'
 
-// this function normalizes different "overloaded" args signatures, returning
-// one predictable args list. ex,
-//   [modulepath, mockdefs, globaldefs, opts]
-//     -> [modulepath, mockdefs, globaldefs, opts]
-//   [modulepath, parent, mockdefs, globaldefs, opts]
-//     -> [modulepath, mockdefs, globaldefs, { ...opts, parent }]
-const argsnormal = (args, argsextra, parent) => {
-  parent = typeof args[1] === 'string' && args[1]
-  args = parent ? [args[0], ...args.slice(2)] : args
-  args[3] = { parent, ...args[3], ...(argsextra && argsextra[0]) }
-  args[4] = (argsextra && argsextra[1]) || args[4]
-
-  return args
-}
-
 const esmock = async (...args) => {
-  const [modulePath, mockDefs, globalDefs, opt = {}, err] = argsnormal(args)
+  const [modulePath, mockDefs, globalDefs, opt = {}, err] = esmockArgs(args)
   const calleePath = (opt.parent || (err || new Error).stack.split('\n')[2])
     .replace(/^.*file:\/\//, '') // rm every before filepath
     .replace(/:[\d]*:[\d]*.*$/, '') // rm line and row number
@@ -47,11 +33,8 @@ const esmock = async (...args) => {
   return esmockModuleImportedSanitize(importedModule, modulePathKey)
 }
 
-esmock.px = async (...args) => (
-  esmock(...argsnormal(args, [{ partial: true }, new Error])))
-
 esmock.p = async (...args) => (
-  esmock(...argsnormal(args, [{ purge: false }, new Error])))
+  esmock(...esmockArgs(args, { purge: false }, new Error)))
 
 esmock.purge = mockModule => {
   if (mockModule && /object|function/.test(typeof mockModule)

--- a/src/esmockArgs.js
+++ b/src/esmockArgs.js
@@ -1,0 +1,14 @@
+// this function normalizes different "overloaded" args signatures, returning
+// one predictable args list. ex,
+//   [modulepath, mockdefs, globaldefs, opts]
+//     -> [modulepath, mockdefs, globaldefs, opts]
+//   [modulepath, parent, mockdefs, globaldefs, opts]
+//     -> [modulepath, mockdefs, globaldefs, { ...opts, parent }]
+export default (args, optsextra, err, parent) => {
+  parent = typeof args[1] === 'string' && args[1]
+  args = parent ? [args[0], ...args.slice(2)] : args
+  args[3] = { parent, ...args[3], ...optsextra }
+  args[4] = err || args[4]
+
+  return args
+}

--- a/src/esmockLoader.js
+++ b/src/esmockLoader.js
@@ -1,8 +1,8 @@
 import process from 'process'
-import esmock from './esmock.js'
+//import esmock from './esmock.js'
 import urlDummy from './esmockDummy.js'
 
-export default esmock
+//export default esmock
 
 const [major, minor] = process.versions.node.split('.').map(it => +it)
 const isLT1612 = major < 16 || (major === 16 && minor < 12)

--- a/src/esmockPartial.js
+++ b/src/esmockPartial.js
@@ -1,0 +1,14 @@
+import esmock from './esmock.js'
+import esmockArgs from './esmockArgs.js'
+
+const esmockPartial = async (...args) => esmock(
+  ...esmockArgs(args, { partial: true }, new Error))
+
+Object.assign(esmockPartial, esmock, {
+  strict: async (...args) => esmock(
+    ...esmockArgs(args, { partial: false }, new Error)),
+  p: async (...args) => esmock(
+    ...esmockArgs(args, { partial: true, purge: false }, new Error))
+})
+
+export default esmockPartial

--- a/src/esmockStrict.js
+++ b/src/esmockStrict.js
@@ -1,0 +1,14 @@
+import esmock from './esmock.js'
+import esmockArgs from './esmockArgs.js'
+
+const esmockStrict = async (...args) => esmock(
+  ...esmockArgs(args, { partial: false }, new Error))
+
+Object.assign(esmockStrict, esmock, {
+  partial: async (...args) => esmock(
+    ...esmockArgs(args, { partial: true }, new Error)),
+  p: async (...args) => esmock(
+    ...esmockArgs(args, { partial: false, purge: false }, new Error))
+})
+
+export default esmockStrict

--- a/tests/package.json
+++ b/tests/package.json
@@ -8,8 +8,18 @@
   },
   "main": "package.json.esmock.export.js",
   "exports": {
-    "types": "./package.json.esmock.export.d.ts",
-    "import": "./package.json.esmock.export.js"
+    ".": {
+      "types": "./package.json.esmock.export.d.ts",
+      "import": "./package.json.esmock.export.js"
+    },
+    "./strict": {
+      "types": "./package.json.esmock.export.d.ts",
+      "import": "./package.json.esmock.export.strict.js"
+    },
+    "./partial": {
+      "types": "./package.json.esmock.export.d.ts",
+      "import": "./package.json.esmock.export.partial.js"
+    }
   },
   "imports": {
     "#sub": "./local/subpath.js"

--- a/tests/package.json.esmock.export.js
+++ b/tests/package.json.esmock.export.js
@@ -1,4 +1,4 @@
-export {default, load, resolve, getSource} from '../src/esmockLoader.js'
+export {load, resolve, getSource} from '../src/esmockLoader.js'
 
 // this file is used in tandem with two other things,
 //

--- a/tests/package.json.esmock.export.partial.js
+++ b/tests/package.json.esmock.export.partial.js
@@ -1,0 +1,1 @@
+export {default} from '../src/esmockPartial.js'

--- a/tests/package.json.esmock.export.strict.js
+++ b/tests/package.json.esmock.export.strict.js
@@ -1,0 +1,1 @@
+export {default} from '../src/esmockStrict.js'

--- a/tests/tests-ava/spec/esmock.ava.only.spec.js
+++ b/tests/tests-ava/spec/esmock.ava.only.spec.js
@@ -1,5 +1,5 @@
 import test from 'ava'
-import esmock from 'esmock'
+import esmock from 'esmock/strict'
 
 // this error can occur when sources do not define 'esmockloader'
 // on 'global' but use a process linked variable instead

--- a/tests/tests-ava/spec/esmock.ava.spec.js
+++ b/tests/tests-ava/spec/esmock.ava.spec.js
@@ -18,14 +18,15 @@ test('should not error when handling non-extensible object', async t => {
   // this error can also occur when an esmocked module is used to
   // mock antother module, where esmock defined default.default on the first
   // module and tried to define again from the outer module
-  const mockedIndex = await esmock.partial('../../local/importsNonDefaultClass.js', {
-    '../../local/exportsNonDefaultClass.js': await esmock.partial(
-      '../../local/exportsNonDefaultClass.js', {
-        '../../local/pathWrap.js': {
-          basename: () => 'mocked basename'
-        }
-      })
-  })
+  const mockedIndex = await esmock
+    .partial('../../local/importsNonDefaultClass.js', {
+      '../../local/exportsNonDefaultClass.js': await esmock
+        .partial('../../local/exportsNonDefaultClass.js', {
+          '../../local/pathWrap.js': {
+            basename: () => 'mocked basename'
+          }
+        })
+    })
 
   t.is(await mockedIndex.callNotifier(), 'mocked basename')
 })

--- a/tests/tests-ava/spec/esmock.ava.spec.js
+++ b/tests/tests-ava/spec/esmock.ava.spec.js
@@ -1,11 +1,11 @@
 import test from 'ava'
-import esmock from 'esmock'
+import esmock from 'esmock/strict'
 import sinon from 'sinon'
 
 test('should not error when handling non-extensible object', async t => {
   // if esmock tries to simulate babel and define default.default
   // runtime error may occur if non-extensible is defined there
-  await esmock.px('../../local/importsNonDefaultClass.js', {
+  await esmock.partial('../../local/importsNonDefaultClass.js', {
     '../../local/exportsNonDefaultClass.js': {
       getNotifier: {
         default: class getNotifier {
@@ -18,8 +18,8 @@ test('should not error when handling non-extensible object', async t => {
   // this error can also occur when an esmocked module is used to
   // mock antother module, where esmock defined default.default on the first
   // module and tried to define again from the outer module
-  const mockedIndex = await esmock.px('../../local/importsNonDefaultClass.js', {
-    '../../local/exportsNonDefaultClass.js': await esmock.px(
+  const mockedIndex = await esmock.partial('../../local/importsNonDefaultClass.js', {
+    '../../local/exportsNonDefaultClass.js': await esmock.partial(
       '../../local/exportsNonDefaultClass.js', {
         '../../local/pathWrap.js': {
           basename: () => 'mocked basename'
@@ -42,7 +42,7 @@ test('should return un-mocked file', async t => {
 })
 
 test('should mock a local file', async t => {
-  const main = await esmock.px('../../local/main.js', {
+  const main = await esmock.partial('../../local/main.js', {
     '../../local/mainUtil.js': {
       createString: () => 'test string'
     }
@@ -165,7 +165,7 @@ test('should return un-mocked file (again)', async t => {
 })
 
 test('should mock local file', async t => {
-  const mainUtil = await esmock.px('../../local/mainUtil.js', {
+  const mainUtil = await esmock.partial('../../local/mainUtil.js', {
     '../../local/mainUtilNamedExports.js': {
       mainUtilNamedExportOne: () => 'foobar'
     }
@@ -181,7 +181,7 @@ test('should mock local file', async t => {
 })
 
 test('should mock module and local file at the same time', async t => {
-  const mainUtil = await esmock.px('../../local/mainUtil.js', {
+  const mainUtil = await esmock.partial('../../local/mainUtil.js', {
     'form-urlencoded': o => JSON.stringify(o),
     '../../local/mainUtilNamedExports.js': {
       mainUtilNamedExportOne: () => 'foobar'
@@ -196,7 +196,7 @@ test('should mock module and local file at the same time', async t => {
 })
 
 test('__esModule definition, inconsequential', async t => {
-  const mainUtil = await esmock.px('../../local/mainUtil.js', {
+  const mainUtil = await esmock.partial('../../local/mainUtil.js', {
     'babelGeneratedDoubleDefault': o => o,
     '../../local/mainUtilNamedExports.js': {
       mainUtilNamedExportOne: () => 'foobar',
@@ -208,7 +208,7 @@ test('__esModule definition, inconsequential', async t => {
 })
 
 test('should work well with sinon', async t => {
-  const mainUtil = await esmock.px('../../local/mainUtil.js', {
+  const mainUtil = await esmock.partial('../../local/mainUtil.js', {
     '../../local/mainUtilNamedExports.js': {
       mainUtilNamedExportOne: sinon.stub().returns('foobar')
     }
@@ -261,7 +261,7 @@ test('should mock core module', async t => {
 })
 
 test('should apply third parameter "global" definitions', async t => {
-  const main = await esmock.px('../../local/main.js', {
+  const main = await esmock.partial('../../local/main.js', {
     '../../local/mainUtil.js': {
       exportedFunction: () => 'foobar'
     }
@@ -333,7 +333,7 @@ test('should have small querystring in stacktrace filename', async t => {
 test('should have small querystring in stacktrace filename, deep', async t => {
   const {
     causeRuntimeErrorFromImportedFile
-  } = await esmock.px('../../local/main.js', {}, {
+  } = await esmock.partial('../../local/main.js', {}, {
     '../../local/mainUtil.js': {
       causeRuntimeError: () => {
         t.nonexistantmethod()
@@ -354,7 +354,7 @@ test('should have small querystring in stacktrace filename, deep', async t => {
 
 test('should have small querystring in stacktrace filename, deep2', async t => {
   const causeDeepErrorParent =
-    await esmock.px('../../local/causeDeepErrorParent.js', {}, {
+    await esmock.partial('../../local/causeDeepErrorParent.js', {}, {
       '../../local/causeDeepErrorGrandChild.js': {
         what: 'now'
       }

--- a/tests/tests-jest/__tests__/esmock.node-jest.test.js
+++ b/tests/tests-jest/__tests__/esmock.node-jest.test.js
@@ -1,4 +1,4 @@
-import esmock from 'esmock'
+import esmock from 'esmock/strict'
 
 test('should mock modules when using jest', async () => {
   const main = await esmock('../../local/main.js', {

--- a/tests/tests-jest/package.json
+++ b/tests/tests-jest/package.json
@@ -1,6 +1,6 @@
 {
   "type": "module",
-  "description": "esmock unit tests, tsm with node native runner",
+  "description": "esmock unit tests, jest with jest-light-runner",
   "repository": {
     "type": "git",
     "url": "https://github.com/iambumblehead/esmock.git"

--- a/tests/tests-no-loader/esmock.loader.test.js
+++ b/tests/tests-no-loader/esmock.loader.test.js
@@ -1,9 +1,9 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import esmock from 'esmock'
+import esmock from 'esmock/strict'
 
 test('should throw error if !esmockloader', async () => {
-  const main = await esmock.px('../local/main.js', {
+  const main = await esmock.partial('../local/main.js', {
     '../local/mainUtil.js': {
       createString: () => 'test string'
     }

--- a/tests/tests-no-loader/esmock.noloader.test.js
+++ b/tests/tests-no-loader/esmock.noloader.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import esmock from 'esmock'
+import esmock from 'esmock/strict'
 
 test('should throw error if !esmockloader', async () => {
   await assert.rejects(() => esmock('./to/module.js'), {

--- a/tests/tests-node/esmock.node.only.test.js
+++ b/tests/tests-node/esmock.node.only.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'assert'
-import esmock from '../../src/esmock.js'
+import esmock from 'esmock/strict'
 
 // this error can occur when sources do not define 'esmockloader'
 // on 'global' but use a process linked variable instead

--- a/tests/tests-node/esmock.node.test.js
+++ b/tests/tests-node/esmock.node.test.js
@@ -1,7 +1,7 @@
 import path from 'path'
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import esmock from '../../src/esmock.js'
+import esmock from 'esmock/strict'
 import sinon from 'sinon'
 
 test('should mock package, even when package is not installed', async () => {
@@ -52,7 +52,7 @@ test('should return un-mocked file', async () => {
 })
 
 test('should mock a local file', async () => {
-  const main = await esmock.px('../local/main.js', {
+  const main = await esmock.partial('../local/main.js', {
     '../local/mainUtil.js': {
       createString: () => 'test string'
     }
@@ -175,7 +175,7 @@ test('should return un-mocked file (again)', async () => {
 })
 
 test('should mock local file', async () => {
-  const mainUtil = await esmock.px('../local/mainUtil.js', {
+  const mainUtil = await esmock.partial('../local/mainUtil.js', {
     '../local/mainUtilNamedExports.js': {
       mainUtilNamedExportOne: () => 'foobar'
     }
@@ -191,7 +191,7 @@ test('should mock local file', async () => {
 })
 
 test('should mock module and local file at the same time', async () => {
-  const mainUtil = await esmock.px('../local/mainUtil.js', {
+  const mainUtil = await esmock.partial('../local/mainUtil.js', {
     'form-urlencoded': o => JSON.stringify(o),
     '../local/mainUtilNamedExports.js': {
       mainUtilNamedExportOne: () => 'foobar'
@@ -206,7 +206,7 @@ test('should mock module and local file at the same time', async () => {
 })
 
 test('__esModule definition, inconsequential', async () => {
-  const mainUtil = await esmock.px('../local/mainUtil.js', {
+  const mainUtil = await esmock.partial('../local/mainUtil.js', {
     'form-urlencoded': o => JSON.stringify(o),
     '../local/mainUtilNamedExports.js': {
       mainUtilNamedExportOne: () => 'foobar',
@@ -222,7 +222,7 @@ test('__esModule definition, inconsequential', async () => {
 })
 
 test('should work well with sinon', async () => {
-  const mainUtil = await esmock.px('../local/mainUtil.js', {
+  const mainUtil = await esmock.partial('../local/mainUtil.js', {
     '../local/mainUtilNamedExports.js': {
       mainUtilNamedExportOne: sinon.stub().returns('foobar')
     }
@@ -275,7 +275,7 @@ test('should mock core module', async () => {
 })
 
 test('should apply third parameter "global" definitions', async () => {
-  const main = await esmock.px('../local/main.js', {
+  const main = await esmock.partial('../local/main.js', {
     '../local/mainUtil.js': {
       exportedFunction: () => 'foobar'
     }
@@ -349,7 +349,7 @@ test('should have small querystring in stacktrace filename', async () => {
 test('should have small querystring in stacktrace filename, deep', async () => {
   const {
     causeRuntimeErrorFromImportedFile
-  } = await esmock.px('../local/main.js', {}, {
+  } = await esmock.partial('../local/main.js', {}, {
     '../local/mainUtil.js': {
       causeRuntimeError: () => {
         assert.nonexistantmethod()
@@ -401,7 +401,7 @@ test('should strict mock by default, partial mock optional', async () => {
       namedexport: 'namedexport'
     }
   })
-  const mainpartial = await esmock.px('../local/main.js', {
+  const mainpartial = await esmock.partial('../local/main.js', {
     '../local/space in path/wild-file.js': {
       default: 'tamed',
       namedexport: 'namedexport'
@@ -422,7 +422,7 @@ test('should strict mock by default, partial mock optional', async () => {
   const pathWrapStrict = await esmock('../local/pathWrap.js', {
     path: { dirname: '/path/to/file' }
   })
-  const pathWrapPartial = await esmock.px('../local/pathWrap.js', {
+  const pathWrapPartial = await esmock.partial('../local/pathWrap.js', {
     path: { dirname: '/path/to/file' }
   })
 

--- a/tests/tests-nodets/esmock.node-ts.test.ts
+++ b/tests/tests-nodets/esmock.node-ts.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'assert';
-import esmock from 'esmock';
+import esmock from 'esmock/strict';
 
 test('should mock ts when using node-ts', { only : true }, async () => {
   const main = await esmock('../local/main.ts', {

--- a/tests/tests-source-map/src/__tests__/index.test.ts
+++ b/tests/tests-source-map/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import test from "ava";
-import esmock from "esmock";
+import esmock from "esmock/strict";
 import { fileURLToPath } from "url";
 
 import type * as indexType from "../index.js";

--- a/tests/tests-tsm/esmock.node-tsm.test.ts
+++ b/tests/tests-tsm/esmock.node-tsm.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'assert';
-import esmock from 'esmock';
+import esmock from 'esmock/strict';
 
 test('should mock ts when using node-ts', async () => {
   const main = await esmock('../local/main.ts', {

--- a/tests/tests-uvu/esmock.uvu.spec.js
+++ b/tests/tests-uvu/esmock.uvu.spec.js
@@ -1,7 +1,7 @@
 import { test } from 'uvu'
 import * as assert from 'uvu/assert'
 import sinon from 'sinon'
-import esmock from 'esmock'
+import esmock from 'esmock/strict'
 
 test('should return un-mocked file', async () => {
   const main = await esmock('../local/main.js')
@@ -15,7 +15,7 @@ test('should return un-mocked file', async () => {
 })
 
 test('should mock a local file', async () => {
-  const main = await esmock.px('../local/main.js', {
+  const main = await esmock.partial('../local/main.js', {
     '../local/mainUtil.js': {
       createString: () => 'test string'
     }
@@ -50,7 +50,7 @@ test('should throw error if local definition file not found', async () => {
 })
 
 test('should mock a module', async () => {
-  const main = await esmock.px('../local/mainUtil.js', {
+  const main = await esmock.partial('../local/mainUtil.js', {
     'form-urlencoded': () => 'mock encode'
   })
 
@@ -134,7 +134,7 @@ test('should return un-mocked file (again)', async () => {
 })
 
 test('should mock local file', async () => {
-  const mainUtil = await esmock.px('../local/mainUtil.js', {
+  const mainUtil = await esmock.partial('../local/mainUtil.js', {
     '../local/mainUtilNamedExports.js': {
       mainUtilNamedExportOne: () => 'foobar'
     }
@@ -150,7 +150,7 @@ test('should mock local file', async () => {
 })
 
 test('should mock module and local file at the same time', async () => {
-  const mainUtil = await esmock.px('../local/mainUtil.js', {
+  const mainUtil = await esmock.partial('../local/mainUtil.js', {
     'form-urlencoded': o => JSON.stringify(o),
     '../local/mainUtilNamedExports.js': {
       mainUtilNamedExportOne: () => 'foobar'
@@ -165,7 +165,7 @@ test('should mock module and local file at the same time', async () => {
 })
 
 test('__esModule definition, inconsequential', async () => {
-  const mainUtil = await esmock.px('../local/mainUtil.js', {
+  const mainUtil = await esmock.partial('../local/mainUtil.js', {
     'babelGeneratedDoubleDefault': o => o,
     '../local/mainUtilNamedExports.js': {
       mainUtilNamedExportOne: () => 'foobar',
@@ -177,7 +177,7 @@ test('__esModule definition, inconsequential', async () => {
 })
 
 test('should work well with sinon', async () => {
-  const mainUtil = await esmock.px('../local/mainUtil.js', {
+  const mainUtil = await esmock.partial('../local/mainUtil.js', {
     '../local/mainUtilNamedExports.js': {
       mainUtilNamedExportOne: sinon.stub().returns('foobar')
     }
@@ -230,7 +230,7 @@ test('should mock core module', async () => {
 })
 
 test('should apply third parameter "global" definitions', async () => {
-  const main = await esmock.px('../local/main.js', {
+  const main = await esmock.partial('../local/main.js', {
     '../local/mainUtil.js': {
       exportedFunction: () => 'foobar'
     }
@@ -303,7 +303,7 @@ test('should have small querystring in stacktrace filename', async () => {
 test('should have small querystring in stacktrace filename, deep', async () => {
   const {
     causeRuntimeErrorFromImportedFile
-  } = await esmock.px('../local/main.js', {}, {
+  } = await esmock.partial('../local/main.js', {}, {
     '../local/mainUtil.js': {
       causeRuntimeError: () => {
         assert.nonexistantmethod()


### PR DESCRIPTION
the purpose of this PR is to remove support for this
```javascript
import esmock from 'esmock'
```
and add support for these,
```javascript
import esmock from 'esmock/partial'
import esmock from 'esmock/strict'
```
this way, the user will choose which variant to use