### PR TITLE
use partial variant as default export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # changelog
 
  * 2.0.0 _Sep.06.2022_
-   * [export both 'partial' and 'strict'](https://github.com/iambumblehead/esmock/pull/140) variants of esmock
+   * [export a 'strict'](https://github.com/iambumblehead/esmock/pull/140) variant of esmock
+   * [use 'partial' mock behaviour with default export](https://github.com/iambumblehead/esmock/pull/141)
+   * updated readme,
+   * resolve error when partial mocking modules not found on filesystem
+   * rename option `isPackageNotFoundError` to `isModuleNotFoundError`
+   * [see the release announcement](https://github.com/iambumblehead/esmock/releases/tag/v2.0.0) for details and migration guide
  * 1.9.8 _Aug.28.2022_
    * [use latest node v18](https://github.com/iambumblehead/esmock/pull/130) for ci-tests, a bug in the ava package prevented this
    * [use latest resolvewithplus](https://github.com/iambumblehead/esmock/pull/130) and remove many lines of code needed for the older variant

--- a/README.md
+++ b/README.md
@@ -90,25 +90,25 @@ test('should mock "await import()" using esmock.p', async () => {
   // a bit more info are found in the wiki guide
 })
 
-// a "partial mock" merges the new and original definitions
-test('should suppport partial mocks', async () => {
+
+test('should suppport "strict" mocking', async () => {
+  // by default, mock definitions are merged w/ original module definitions
   const pathWrap = await esmock('../src/pathWrap.js', {
-    path: { dirname: () => '/path/to/file' }
-  })
-
-  // an error, because path.basename was not defined
-  await assert.rejects(async () => pathWrap.basename('/dog.png'), {
-    name: 'TypeError',
-    message: 'path.basename is not a function'
-  })
-
-  // use esmock.partial to create a "partial mock"
-  const pathWrapPartial = await esmock.partial('../src/pathWrap.js', {
     path: { dirname: () => '/home/' }
   })
 
   // no error, because "core" path.basename was merged into the mock
-  assert.deepEqual(pathWrapPartial.basename('/dog.png'), 'dog.png')
-  assert.deepEqual(pathWrapPartial.dirname(), '/home/')
+  assert.deepEqual(pathWrap.basename('/dog.png'), 'dog.png')
+  assert.deepEqual(pathWrap.dirname(), '/home/')
+
+  const pathWrapStrict = await esmock.strict('../src/pathWrap.js', {
+    path: { dirname: () => '/path/to/file' }
+  })
+
+  // an error, because the path mock did not define path.basename
+  await assert.rejects(async () => pathWrapStrict.basename('/dog.png'), {
+    name: 'TypeError',
+    message: 'path.basename is not a function'
+  })
 })
 ```

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ test('should support "strict" mocking, at esmock.strict', async () => {
     path: { dirname: () => '/path/to/file' }
   })
 
-  // an error, because the path mock did not define path.basename
+  // error, because the "path" mock above does not define path.basename
   await assert.rejects(async () => pathWrapper.basename('/dog.png'), {
     name: 'TypeError',
     message: 'path.basename is not a function'

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@
 [2]: https://github.com/iambumblehead/esmock "esmock"
 [3]: https://github.com/iambumblehead/esmock/tree/master/tests "tests"
 
-
 `esmock` is used with node's --loader
 ``` json
 {
@@ -90,23 +89,14 @@ test('should mock "await import()" using esmock.p', async () => {
   // a bit more info are found in the wiki guide
 })
 
-
-test('should suppport "strict" mocking', async () => {
-  // by default, mock definitions are merged w/ original module definitions
-  const pathWrap = await esmock('../src/pathWrap.js', {
-    path: { dirname: () => '/home/' }
-  })
-
-  // no error, because "core" path.basename was merged into the mock
-  assert.deepEqual(pathWrap.basename('/dog.png'), 'dog.png')
-  assert.deepEqual(pathWrap.dirname(), '/home/')
-
-  const pathWrapStrict = await esmock.strict('../src/pathWrap.js', {
+test('should support "strict" mocking, at esmock.strict', async () => {
+  // strict mock definitions are not merged w/ original module definitions
+  const pathWrapper = await esmock.strict('../src/pathWrapper.js', {
     path: { dirname: () => '/path/to/file' }
   })
 
   // an error, because the path mock did not define path.basename
-  await assert.rejects(async () => pathWrapStrict.basename('/dog.png'), {
+  await assert.rejects(async () => pathWrapper.basename('/dog.png'), {
     name: 'TypeError',
     message: 'path.basename is not a function'
   })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esmock",
   "type": "module",
-  "version": "1.9.8",
+  "version": "2.0.0",
   "license": "ISC",
   "readmeFilename": "README.md",
   "description": "provides native ESM import mocking for unit tests",

--- a/src/esmock.d.ts
+++ b/src/esmock.d.ts
@@ -23,7 +23,7 @@ declare namespace esmock {
   interface Options {
     strict?: boolean | undefined;
     purge?: boolean | undefined;
-    isPackageNotFoundError?: boolean | undefined;
+    isModuleNotFoundError?: boolean | undefined;
     parent?: string | undefined;
   }
 

--- a/src/esmock.d.ts
+++ b/src/esmock.d.ts
@@ -1,7 +1,8 @@
 /**
  * Mocks imports for the module specified by {@link modulePath}.
  *
- * The provided mocks replace the imported modules _fully_.
+ * By default, mock definitions are merged with the original module definitions.
+ * To disable the default behaviour, Use esmock.strict.
  *
  * @param modulePath The module whose imports will be mocked.
  * @param parent A URL to resolve specifiers relative to; typically `import.meta.url`.
@@ -20,35 +21,10 @@ declare function esmock(modulePath: string, mockDefs?: Record<string, any>, glob
 
 declare namespace esmock {
   interface Options {
-    partial?: boolean | undefined;
+    strict?: boolean | undefined;
     purge?: boolean | undefined;
     isPackageNotFoundError?: boolean | undefined;
     parent?: string | undefined;
-  }
-
-  /**
-   * Mocks imports for the module specified by {@link modulePath}.
-   *
-   * This "partial" variant gives mock definitions that are merged with the
-   * original module definitions.
-   *
-   * @param modulePath The module whose imports will be mocked.
-   * @param parent A URL to resolve specifiers relative to; typically `import.meta.url`.
-   *               If not specified, it will be inferred via the stack, which may not work
-   *               if source maps are in use.
-   * @param mockDefs A mapping of import specifiers to mocked module objects; these mocks will
-   *                 only be used for imports resolved in the module specified by {@link modulePath}.
-   * @param globalDefs A mapping of import specifiers to mocked module objects; these mocks will
-   *                   apply to imports within the module specified by {@link modulePath}, as well
-   *                   as any transitively imported modules.
-   * @param opt
-   * @returns The result of importing {@link modulePath}, similar to `import(modulePath)`.
-   */
-  function partial(modulePath: string, parent: string, mockDefs?: Record<string, any>, globalDefs?: Record<string, any>, opt?: esmock.Options): any;
-  function partial(modulePath: string, mockDefs?: Record<string, any>, globalDefs?: Record<string, any>, opt?: esmock.Options): any;
-  export namespace partial {
-    function p(modulePath: string, parent: string, mockDefs?: Record<string, any>, globalDefs?: Record<string, any>, opt?: esmock.Options): any;
-    function p(modulePath: string, mockDefs?: Record<string, any>, globalDefs?: Record<string, any>, opt?: esmock.Options): any;
   }
 
   /**
@@ -104,4 +80,4 @@ declare namespace esmock {
 }
 
 export default esmock;
-export { esmock as partial, esmock as strict };
+export { esmock as strict };

--- a/src/esmock.js
+++ b/src/esmock.js
@@ -32,18 +32,15 @@ const esmock = async (...args) => {
 
   return esmockModuleImportedSanitize(importedModule, modulePathKey)
 }
+esmock.p = async (...args) => esmock(
+  ...esmockArgs(args, { purge: false }, new Error))
 
 const strict = async (...args) => esmock(
-  ...esmockArgs(args, { partial: false }, new Error))
+  ...esmockArgs(args, { strict: true }, new Error))
 strict.p = async (...args) => esmock(
-  ...esmockArgs(args, { partial: false, purge: false }, new Error))
+  ...esmockArgs(args, { strict: true, purge: false }, new Error))
 
-const partial = async (...args) => esmock(
-  ...esmockArgs(args, { partial: true }, new Error))
-partial.p = async (...args) => esmock(
-  ...esmockArgs(args, { partial: true, purge: false }, new Error))
-
-Object.assign(esmock, strict, { strict, partial })
+Object.assign(esmock, { strict })
 
 esmock.purge = mockModule => {
   if (mockModule && /object|function/.test(typeof mockModule)
@@ -53,4 +50,4 @@ esmock.purge = mockModule => {
 
 esmock.esmockCache = esmockCache
 
-export {esmock as default, partial, strict}
+export {esmock as default, strict}

--- a/src/esmockModule.js
+++ b/src/esmockModule.js
@@ -126,7 +126,7 @@ const esmockModulesCreate = async (pathCallee, pathModule, esmockKey, defs, keys
     return mocks
 
   let mockedPathFull = resolvewith(keys[0], pathCallee)
-  if (!mockedPathFull && opt.isPackageNotFoundError === false) {
+  if (!mockedPathFull && opt.isModuleNotFoundError === false) {
     mockedPathFull = 'file:///' + keys[0]
     opt = Object.assign({ isfound: false }, opt)
   }

--- a/src/esmockModule.js
+++ b/src/esmockModule.js
@@ -99,7 +99,7 @@ const esmockNextKey = ((key = 0) => () => ++key)()
 // eslint-disable-next-line max-len
 const esmockModuleCreate = async (esmockKey, key, mockPathFull, mockDef, opt) => {
   const isesm = esmockModuleIsESM(mockPathFull)
-  const originalDefinition = opt.partial ? await import(mockPathFull) : null
+  const originalDefinition = opt.strict || await import(mockPathFull)
   const mockDefinitionFinal = esmockModuleApply(
     originalDefinition, mockDef, mockPathFull)
   const mockExportNames = Object.keys(mockDefinitionFinal).sort().join()

--- a/src/esmockModule.js
+++ b/src/esmockModule.js
@@ -99,7 +99,8 @@ const esmockNextKey = ((key = 0) => () => ++key)()
 // eslint-disable-next-line max-len
 const esmockModuleCreate = async (esmockKey, key, mockPathFull, mockDef, opt) => {
   const isesm = esmockModuleIsESM(mockPathFull)
-  const originalDefinition = opt.strict || await import(mockPathFull)
+  const originalDefinition = opt.strict || opt.isfound === false
+    || await import(mockPathFull)
   const mockDefinitionFinal = esmockModuleApply(
     originalDefinition, mockDef, mockPathFull)
   const mockExportNames = Object.keys(mockDefinitionFinal).sort().join()

--- a/tests/tests-ava/spec/esmock.ava.spec.js
+++ b/tests/tests-ava/spec/esmock.ava.spec.js
@@ -5,7 +5,7 @@ import sinon from 'sinon'
 test('should not error when handling non-extensible object', async t => {
   // if esmock tries to simulate babel and define default.default
   // runtime error may occur if non-extensible is defined there
-  await esmock.partial('../../local/importsNonDefaultClass.js', {
+  await esmock('../../local/importsNonDefaultClass.js', {
     '../../local/exportsNonDefaultClass.js': {
       getNotifier: {
         default: class getNotifier {
@@ -18,9 +18,9 @@ test('should not error when handling non-extensible object', async t => {
   // this error can also occur when an esmocked module is used to
   // mock antother module, where esmock defined default.default on the first
   // module and tried to define again from the outer module
-  const mockedIndex = await esmock.partial(
+  const mockedIndex = await esmock(
     '../../local/importsNonDefaultClass.js', {
-      '../../local/exportsNonDefaultClass.js': await esmock.partial(
+      '../../local/exportsNonDefaultClass.js': await esmock(
         '../../local/exportsNonDefaultClass.js', {
           '../../local/pathWrap.js': {
             basename: () => 'mocked basename'
@@ -43,7 +43,7 @@ test('should return un-mocked file', async t => {
 })
 
 test('should mock a local file', async t => {
-  const main = await esmock.partial('../../local/main.js', {
+  const main = await esmock('../../local/main.js', {
     '../../local/mainUtil.js': {
       createString: () => 'test string'
     }
@@ -166,7 +166,7 @@ test('should return un-mocked file (again)', async t => {
 })
 
 test('should mock local file', async t => {
-  const mainUtil = await esmock.partial('../../local/mainUtil.js', {
+  const mainUtil = await esmock('../../local/mainUtil.js', {
     '../../local/mainUtilNamedExports.js': {
       mainUtilNamedExportOne: () => 'foobar'
     }
@@ -182,7 +182,7 @@ test('should mock local file', async t => {
 })
 
 test('should mock module and local file at the same time', async t => {
-  const mainUtil = await esmock.partial('../../local/mainUtil.js', {
+  const mainUtil = await esmock('../../local/mainUtil.js', {
     'form-urlencoded': o => JSON.stringify(o),
     '../../local/mainUtilNamedExports.js': {
       mainUtilNamedExportOne: () => 'foobar'
@@ -197,7 +197,7 @@ test('should mock module and local file at the same time', async t => {
 })
 
 test('__esModule definition, inconsequential', async t => {
-  const mainUtil = await esmock.partial('../../local/mainUtil.js', {
+  const mainUtil = await esmock('../../local/mainUtil.js', {
     'babelGeneratedDoubleDefault': o => o,
     '../../local/mainUtilNamedExports.js': {
       mainUtilNamedExportOne: () => 'foobar',
@@ -209,7 +209,7 @@ test('__esModule definition, inconsequential', async t => {
 })
 
 test('should work well with sinon', async t => {
-  const mainUtil = await esmock.partial('../../local/mainUtil.js', {
+  const mainUtil = await esmock('../../local/mainUtil.js', {
     '../../local/mainUtilNamedExports.js': {
       mainUtilNamedExportOne: sinon.stub().returns('foobar')
     }
@@ -262,7 +262,7 @@ test('should mock core module', async t => {
 })
 
 test('should apply third parameter "global" definitions', async t => {
-  const main = await esmock.partial('../../local/main.js', {
+  const main = await esmock('../../local/main.js', {
     '../../local/mainUtil.js': {
       exportedFunction: () => 'foobar'
     }
@@ -334,7 +334,7 @@ test('should have small querystring in stacktrace filename', async t => {
 test('should have small querystring in stacktrace filename, deep', async t => {
   const {
     causeRuntimeErrorFromImportedFile
-  } = await esmock.partial('../../local/main.js', {}, {
+  } = await esmock('../../local/main.js', {}, {
     '../../local/mainUtil.js': {
       causeRuntimeError: () => {
         t.nonexistantmethod()
@@ -355,7 +355,7 @@ test('should have small querystring in stacktrace filename, deep', async t => {
 
 test('should have small querystring in stacktrace filename, deep2', async t => {
   const causeDeepErrorParent =
-    await esmock.partial('../../local/causeDeepErrorParent.js', {}, {
+    await esmock('../../local/causeDeepErrorParent.js', {}, {
       '../../local/causeDeepErrorGrandChild.js': {
         what: 'now'
       }

--- a/tests/tests-no-loader/esmock.loader.test.js
+++ b/tests/tests-no-loader/esmock.loader.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import esmock from 'esmock'
 
 test('should throw error if !esmockloader', async () => {
-  const main = await esmock.partial('../local/main.js', {
+  const main = await esmock('../local/main.js', {
     '../local/mainUtil.js': {
       createString: () => 'test string'
     }

--- a/tests/tests-node/esmock.node.importing.test.js
+++ b/tests/tests-node/esmock.node.importing.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import esmock, { partial, strict } from 'esmock'
+import esmock, { strict } from 'esmock'
 
 const isPassingPartial = async esmockPartial => {
   const main = await esmockPartial('../local/main.js', {
@@ -27,10 +27,8 @@ const isPassingStrict = async esmockStrict => {
 }
 
 test('should export esmock partial', async () => {
-  await isPassingPartial(partial)
-  await isPassingPartial(partial.p)
-  await isPassingPartial(esmock.partial)
-  await isPassingPartial(esmock.partial.p)
+  await isPassingPartial(esmock)
+  await isPassingPartial(esmock.p)
 })
 
 test('should export esmock strict', async () => {
@@ -38,6 +36,4 @@ test('should export esmock strict', async () => {
   await isPassingStrict(strict.p)
   await isPassingStrict(esmock.strict)
   await isPassingStrict(esmock.strict.p)
-  await isPassingStrict(esmock)
-  await isPassingStrict(esmock.p)
 })

--- a/tests/tests-node/esmock.node.test.js
+++ b/tests/tests-node/esmock.node.test.js
@@ -10,7 +10,7 @@ test('should mock package, even when package is not installed', async () => {
       h: (...args) => args
     }
   }, {}, {
-    isPackageNotFoundError: false
+    isModuleNotFoundError: false
   })
 
   assert.strictEqual(component()[0], 'svg')
@@ -22,7 +22,7 @@ test('should mock package, even when package is not installed', async () => {
       h: (...args) => args
     }
   }, {
-    isPackageNotFoundError: false
+    isModuleNotFoundError: false
   })
 
   assert.strictEqual(component()[0], 'svg')

--- a/tests/tests-node/esmock.node.test.js
+++ b/tests/tests-node/esmock.node.test.js
@@ -52,7 +52,7 @@ test('should return un-mocked file', async () => {
 })
 
 test('should mock a local file', async () => {
-  const main = await esmock.partial('../local/main.js', {
+  const main = await esmock('../local/main.js', {
     '../local/mainUtil.js': {
       createString: () => 'test string'
     }
@@ -175,7 +175,7 @@ test('should return un-mocked file (again)', async () => {
 })
 
 test('should mock local file', async () => {
-  const mainUtil = await esmock.partial('../local/mainUtil.js', {
+  const mainUtil = await esmock('../local/mainUtil.js', {
     '../local/mainUtilNamedExports.js': {
       mainUtilNamedExportOne: () => 'foobar'
     }
@@ -191,7 +191,7 @@ test('should mock local file', async () => {
 })
 
 test('should mock module and local file at the same time', async () => {
-  const mainUtil = await esmock.partial('../local/mainUtil.js', {
+  const mainUtil = await esmock('../local/mainUtil.js', {
     'form-urlencoded': o => JSON.stringify(o),
     '../local/mainUtilNamedExports.js': {
       mainUtilNamedExportOne: () => 'foobar'
@@ -206,7 +206,7 @@ test('should mock module and local file at the same time', async () => {
 })
 
 test('__esModule definition, inconsequential', async () => {
-  const mainUtil = await esmock.partial('../local/mainUtil.js', {
+  const mainUtil = await esmock('../local/mainUtil.js', {
     'form-urlencoded': o => JSON.stringify(o),
     '../local/mainUtilNamedExports.js': {
       mainUtilNamedExportOne: () => 'foobar',
@@ -222,7 +222,7 @@ test('__esModule definition, inconsequential', async () => {
 })
 
 test('should work well with sinon', async () => {
-  const mainUtil = await esmock.partial('../local/mainUtil.js', {
+  const mainUtil = await esmock('../local/mainUtil.js', {
     '../local/mainUtilNamedExports.js': {
       mainUtilNamedExportOne: sinon.stub().returns('foobar')
     }
@@ -275,7 +275,7 @@ test('should mock core module', async () => {
 })
 
 test('should apply third parameter "global" definitions', async () => {
-  const main = await esmock.partial('../local/main.js', {
+  const main = await esmock('../local/main.js', {
     '../local/mainUtil.js': {
       exportedFunction: () => 'foobar'
     }
@@ -349,7 +349,7 @@ test('should have small querystring in stacktrace filename', async () => {
 test('should have small querystring in stacktrace filename, deep', async () => {
   const {
     causeRuntimeErrorFromImportedFile
-  } = await esmock.partial('../local/main.js', {}, {
+  } = await esmock('../local/main.js', {}, {
     '../local/mainUtil.js': {
       causeRuntimeError: () => {
         assert.nonexistantmethod()
@@ -395,13 +395,13 @@ test('should not error when mocked file has space in path', async () => {
 
 test('should strict mock by default, partial mock optional', async () => {
   const wildfile = await import('../local/space in path/wild-file.js')
-  const mainstrict = await esmock('../local/main.js', {
+  const mainstrict = await esmock.strict('../local/main.js', {
     '../local/space in path/wild-file.js': {
       default: 'tamed',
       namedexport: 'namedexport'
     }
   })
-  const mainpartial = await esmock.partial('../local/main.js', {
+  const mainpartial = await esmock('../local/main.js', {
     '../local/space in path/wild-file.js': {
       default: 'tamed',
       namedexport: 'namedexport'
@@ -419,10 +419,10 @@ test('should strict mock by default, partial mock optional', async () => {
 })
 
 test('should strict mock by default, partial mock optional', async () => {
-  const pathWrapStrict = await esmock('../local/pathWrap.js', {
+  const pathWrapStrict = await esmock.strict('../local/pathWrap.js', {
     path: { dirname: '/path/to/file' }
   })
-  const pathWrapPartial = await esmock.partial('../local/pathWrap.js', {
+  const pathWrapPartial = await esmock('../local/pathWrap.js', {
     path: { dirname: '/path/to/file' }
   })
 

--- a/tests/tests-nodets/esmock.node-ts.importing.test.ts
+++ b/tests/tests-nodets/esmock.node-ts.importing.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import esmock, { partial, strict } from 'esmock'
+import esmock, { strict } from 'esmock'
 
 const isPassingPartial = async esmockPartial => {
   const main = await esmockPartial('../local/main.js', {
@@ -27,10 +27,8 @@ const isPassingStrict = async esmockStrict => {
 }
 
 test('should export esmock partial', async () => {
-  await isPassingPartial(partial)
-  await isPassingPartial(partial.p)
-  await isPassingPartial(esmock.partial)
-  await isPassingPartial(esmock.partial.p)
+  await isPassingPartial(esmock)
+  await isPassingPartial(esmock.p)
 })
 
 test('should export esmock strict', async () => {
@@ -38,6 +36,4 @@ test('should export esmock strict', async () => {
   await isPassingStrict(strict.p)
   await isPassingStrict(esmock.strict)
   await isPassingStrict(esmock.strict.p)
-  await isPassingStrict(esmock)
-  await isPassingStrict(esmock.p)
 })

--- a/tests/tests-source-map/src/__tests__/index.test.ts
+++ b/tests/tests-source-map/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import test from "ava";
-import esmock from "esmock";
+import { strict as esmock } from "esmock";
 import { fileURLToPath } from "url";
 
 import type * as indexType from "../index.js";

--- a/tests/tests-uvu/esmock.uvu.spec.js
+++ b/tests/tests-uvu/esmock.uvu.spec.js
@@ -15,7 +15,7 @@ test('should return un-mocked file', async () => {
 })
 
 test('should mock a local file', async () => {
-  const main = await esmock.partial('../local/main.js', {
+  const main = await esmock('../local/main.js', {
     '../local/mainUtil.js': {
       createString: () => 'test string'
     }
@@ -50,7 +50,7 @@ test('should throw error if local definition file not found', async () => {
 })
 
 test('should mock a module', async () => {
-  const main = await esmock.partial('../local/mainUtil.js', {
+  const main = await esmock('../local/mainUtil.js', {
     'form-urlencoded': () => 'mock encode'
   })
 
@@ -134,7 +134,7 @@ test('should return un-mocked file (again)', async () => {
 })
 
 test('should mock local file', async () => {
-  const mainUtil = await esmock.partial('../local/mainUtil.js', {
+  const mainUtil = await esmock('../local/mainUtil.js', {
     '../local/mainUtilNamedExports.js': {
       mainUtilNamedExportOne: () => 'foobar'
     }
@@ -150,7 +150,7 @@ test('should mock local file', async () => {
 })
 
 test('should mock module and local file at the same time', async () => {
-  const mainUtil = await esmock.partial('../local/mainUtil.js', {
+  const mainUtil = await esmock('../local/mainUtil.js', {
     'form-urlencoded': o => JSON.stringify(o),
     '../local/mainUtilNamedExports.js': {
       mainUtilNamedExportOne: () => 'foobar'
@@ -165,7 +165,7 @@ test('should mock module and local file at the same time', async () => {
 })
 
 test('__esModule definition, inconsequential', async () => {
-  const mainUtil = await esmock.partial('../local/mainUtil.js', {
+  const mainUtil = await esmock('../local/mainUtil.js', {
     'babelGeneratedDoubleDefault': o => o,
     '../local/mainUtilNamedExports.js': {
       mainUtilNamedExportOne: () => 'foobar',
@@ -177,7 +177,7 @@ test('__esModule definition, inconsequential', async () => {
 })
 
 test('should work well with sinon', async () => {
-  const mainUtil = await esmock.partial('../local/mainUtil.js', {
+  const mainUtil = await esmock('../local/mainUtil.js', {
     '../local/mainUtilNamedExports.js': {
       mainUtilNamedExportOne: sinon.stub().returns('foobar')
     }
@@ -230,7 +230,7 @@ test('should mock core module', async () => {
 })
 
 test('should apply third parameter "global" definitions', async () => {
-  const main = await esmock.partial('../local/main.js', {
+  const main = await esmock('../local/main.js', {
     '../local/mainUtil.js': {
       exportedFunction: () => 'foobar'
     }
@@ -303,7 +303,7 @@ test('should have small querystring in stacktrace filename', async () => {
 test('should have small querystring in stacktrace filename, deep', async () => {
   const {
     causeRuntimeErrorFromImportedFile
-  } = await esmock.partial('../local/main.js', {}, {
+  } = await esmock('../local/main.js', {}, {
     '../local/mainUtil.js': {
       causeRuntimeError: () => {
         assert.nonexistantmethod()


### PR DESCRIPTION
 * update sources and tests to use partial variant as default export,
 * update readme,
 * remove esmock.partial and partial export definitions to reduce typescript maintenance burden
 * resolve error when using partial mocking with modules not found on filesystem