### PR TITLE
use same arg names at main esmock.js file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # changelog
 
+ * 2.0.3 _tbd_
+   * [simplify main esmock.js file,](https://github.com/iambumblehead/esmock/pull/158) slightly reducing install size
  * 2.0.2 _Sep.21.2022_
    * [simplifications,](https://github.com/iambumblehead/esmock/pull/153) slightly reducing install size
    * [update jest and jest-light-runner versions](https://github.com/iambumblehead/esmock/pull/156/files) used in unit-tests

--- a/src/esmock.js
+++ b/src/esmock.js
@@ -3,9 +3,9 @@ import esmockModule from './esmockModule.js'
 import esmockCache from './esmockCache.js'
 import esmockArgs from './esmockArgs.js'
 
-const esmock = async (...args) => {
-  const [modulePath, mockDefs, globalDefs, opt = {}, err] = esmockArgs(args)
-  const calleePath = (opt.parent || (err || new Error).stack.split('\n')[2])
+const esmockGo = opts => async (...args) => {
+  const [moduleId, defs, gefs, opt = {}, err] = esmockArgs(args, opts)
+  const parent = (opt.parent || err.stack.split('\n')[3])
     .replace(/^.*file:\/\//, '') // rm every before filepath
     .replace(/:[\d]*:[\d]*.*$/, '') // rm line and row number
     .replace(/^.*:/, '') // rm windows-style drive location
@@ -15,7 +15,7 @@ const esmock = async (...args) => {
     throw new Error('process must be started with --loader=esmock')
 
   const modulePathKey = await esmockModule(
-    calleePath, modulePath, mockDefs || {}, globalDefs || {}, opt)
+    parent, moduleId, defs || {}, gefs || {}, opt)
 
   const importedModule = await import(modulePathKey)
 
@@ -25,19 +25,14 @@ const esmock = async (...args) => {
   return esmockModule.sanitize(importedModule, modulePathKey)
 }
 
-const strict = async (...args) => esmock(
-  ...esmockArgs(args, { strict: true }, new Error))
-esmock.p = async (...args) => esmock(
-  ...esmockArgs(args, { purge: false }, new Error))
-strict.p = async (...args) => esmock(
-  ...esmockArgs(args, { strict: true, purge: false }, new Error))
-
-Object.assign(esmock, { strict })
-
-esmock.purge = mockModule => mockModule
+const purge = mockModule => mockModule
   && /object|function/.test(typeof mockModule) && 'esmockKey' in mockModule
   && esmockModule.purge(mockModule.esmockKey)
 
-esmock.esmockCache = esmockCache
+const strict = Object.assign(esmockGo({ strict: true }), {
+  purge, cache: esmockCache, p: esmockGo({ strict: true, purge: false }) })
+
+const esmock = Object.assign(esmockGo(), {
+  purge, cache: esmockCache, p: esmockGo({ purge: false }), strict })
 
 export {esmock as default, strict}

--- a/src/esmock.js
+++ b/src/esmock.js
@@ -4,8 +4,8 @@ import esmockCache from './esmockCache.js'
 import esmockArgs from './esmockArgs.js'
 
 const esmockGo = opts => async (...args) => {
-  const [moduleId, defs, gefs, opt = {}, err] = esmockArgs(args, opts)
-  const parent = (opt.parent || err.stack.split('\n')[3])
+  const [moduleId, defs = {}, gdefs = {}, opt, e] = esmockArgs(args, opts)
+  const parent = (opt.parent || e.stack.split('\n')[3])
     .replace(/^.*file:\/\//, '') // rm every before filepath
     .replace(/:[\d]*:[\d]*.*$/, '') // rm line and row number
     .replace(/^.*:/, '') // rm windows-style drive location
@@ -14,15 +14,13 @@ const esmockGo = opts => async (...args) => {
   if (!esmockIsLoader())
     throw new Error('process must be started with --loader=esmock')
 
-  const modulePathKey = await esmockModule(
-    parent, moduleId, defs || {}, gefs || {}, opt)
-
-  const importedModule = await import(modulePathKey)
+  const fileURLKey = await esmockModule(parent, moduleId, defs, gdefs, opt)
+  const importedModule = await import(fileURLKey)
 
   if (opt.purge !== false)
-    esmockModule.purge(modulePathKey)
+    esmockModule.purge(fileURLKey)
 
-  return esmockModule.sanitize(importedModule, modulePathKey)
+  return esmockModule.sanitize(importedModule, fileURLKey)
 }
 
 const purge = mockModule => mockModule

--- a/src/esmockArgs.js
+++ b/src/esmockArgs.js
@@ -8,7 +8,7 @@ export default (args, optsextra, err, parent) => {
   parent = typeof args[1] === 'string' && args[1]
   args = parent ? [args[0], ...args.slice(2)] : args
   args[3] = { parent, ...args[3], ...optsextra }
-  args[4] = err || args[4]
+  args[4] = err || args[4] || new Error
 
   return args
 }

--- a/tests/tests-ava/spec/esmock.ava.spec.js
+++ b/tests/tests-ava/spec/esmock.ava.spec.js
@@ -131,11 +131,11 @@ test('should purge local and global mocks', async t => {
   })
 
   const keys = Object
-    .keys(esmock.esmockCache.mockDefs)
+    .keys(esmock.cache.mockDefs)
     .filter(key => /esmockKey=999/.test(key))
 
   t.truthy(keys.length)
-  t.true(keys.every(key => esmock.esmockCache.mockDefs[key] === null))
+  t.true(keys.every(key => esmock.cache.mockDefs[key] === null))
 })
 
 test('should mock a module, many times differently', async t => {
@@ -311,12 +311,12 @@ test('mocks inline `async import("name")`', async t => {
   const [, key] = writeJSConfigFile.esmockKey.match(/esmk=(\d*)/)
   const keyRe = new RegExp(`esmockKey=${key}[^d]`)
 
-  const moduleKeys = Object.keys(esmock.esmockCache.mockDefs)
+  const moduleKeys = Object.keys(esmock.cache.mockDefs)
     .filter(moduleKey => keyRe.test(moduleKey))
 
-  t.true(moduleKeys.every(mkey => esmock.esmockCache.mockDefs[mkey]))
+  t.true(moduleKeys.every(mkey => esmock.cache.mockDefs[mkey]))
   esmock.purge(writeJSConfigFile)
-  t.true(moduleKeys.every(mkey => esmock.esmockCache.mockDefs[mkey] === null))
+  t.true(moduleKeys.every(mkey => esmock.cache.mockDefs[mkey] === null))
 })
 
 test('should have small querystring in stacktrace filename', async t => {

--- a/tests/tests-node/esmock.node.test.js
+++ b/tests/tests-node/esmock.node.test.js
@@ -140,11 +140,11 @@ test('should purge local and global mocks', async () => {
   })
 
   const keys = Object
-    .keys(esmock.esmockCache.mockDefs)
+    .keys(esmock.cache.mockDefs)
     .filter(key => /esmockKey=999/.test(key))
 
   assert.ok(keys.length)
-  assert.ok(keys.every(key => esmock.esmockCache.mockDefs[key] === null))
+  assert.ok(keys.every(key => esmock.cache.mockDefs[key] === null))
 })
 
 test('should mock a module, many times differently', async () => {
@@ -325,13 +325,13 @@ test('mocks inline `async import("name")`', async () => {
   const [, key] = writeJSConfigFile.esmockKey.match(/esmk=(\d*)/)
   const keyRe = new RegExp(`esmockKey=${key}[^d]`)
 
-  const moduleKeys = Object.keys(esmock.esmockCache.mockDefs)
+  const moduleKeys = Object.keys(esmock.cache.mockDefs)
     .filter(moduleKey => keyRe.test(moduleKey))
 
-  assert.ok(moduleKeys.every(mkey => esmock.esmockCache.mockDefs[mkey]))
+  assert.ok(moduleKeys.every(mkey => esmock.cache.mockDefs[mkey]))
   esmock.purge(writeJSConfigFile)
   // eslint-disable-next-line max-len
-  assert.ok(moduleKeys.every(mkey => esmock.esmockCache.mockDefs[mkey] === null))
+  assert.ok(moduleKeys.every(mkey => esmock.cache.mockDefs[mkey] === null))
 })
 
 test('should have small querystring in stacktrace filename', async () => {

--- a/tests/tests-uvu/esmock.uvu.spec.js
+++ b/tests/tests-uvu/esmock.uvu.spec.js
@@ -100,11 +100,11 @@ test('should purge local and global mocks', async () => {
   })
 
   const keys = Object
-    .keys(esmock.esmockCache.mockDefs)
+    .keys(esmock.cache.mockDefs)
     .filter(key => /esmockKey=999/.test(key))
 
   assert.ok(keys.length)
-  assert.ok(keys.every(key => esmock.esmockCache.mockDefs[key] === null))
+  assert.ok(keys.every(key => esmock.cache.mockDefs[key] === null))
 })
 
 test('should mock a module, many times differently', async () => {
@@ -280,13 +280,12 @@ test('mocks inline `async import("name")`', async () => {
   const [, key] = writeJSConfigFile.esmockKey.match(/esmk=(\d*)/)
   const keyRe = new RegExp(`esmockKey=${key}[^d]`)
 
-  const moduleKeys = Object.keys(esmock.esmockCache.mockDefs)
+  const moduleKeys = Object.keys(esmock.cache.mockDefs)
     .filter(moduleKey => keyRe.test(moduleKey))
 
-  assert.ok(moduleKeys.every(mkey => esmock.esmockCache.mockDefs[mkey]))
+  assert.ok(moduleKeys.every(mkey => esmock.cache.mockDefs[mkey]))
   esmock.purge(writeJSConfigFile)
-  assert.ok(
-    moduleKeys.every(mkey => esmock.esmockCache.mockDefs[mkey] === null))
+  assert.ok(moduleKeys.every(mkey => esmock.cache.mockDefs[mkey] === null))
 })
 
 test('should have small querystring in stacktrace filename', async () => {


### PR DESCRIPTION
This PR simplifies esmock.js slightly and adds extra "purge" and "cache" definitions to esmock.strict. Arg names at esmock.js are renamed to match the names used in esmockModule.js, names like "moduleId" and "gdefs"