### PR TITLE
try to simplify esmock.d.ts types file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # changelog
 
- * 2.0.3 _tbd_
+ * 2.0.3 _Sep.24.2022_
+   * [simplify esmock.d.ts file,](https://github.com/iambumblehead/esmock/pull/163) reducing documentation and using shorter param names
    * [simplify args normalization](https://github.com/iambumblehead/esmock/pull/162) and drop support for opts.parent
    * [simplify](https://github.com/iambumblehead/esmock/pull/159/files) [path-extraction](https://github.com/iambumblehead/esmock/pull/161) to use one regexp rather than four
    * [use newer resolvewithplus](https://github.com/iambumblehead/resolvewithplus/releases/tag/v1.0.2) with better fileurl support

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esmock",
   "type": "module",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "ISC",
   "readmeFilename": "README.md",
   "description": "provides native ESM import mocking for unit tests",

--- a/src/esmock.d.ts
+++ b/src/esmock.d.ts
@@ -1,3 +1,12 @@
+type mocks = Record<string, any>
+
+type opts = {
+  strict?: boolean | undefined,
+  purge?: boolean | undefined,
+  isModuleNotFoundError?: boolean | undefined,
+  parent?: string | undefined
+}
+
 /**
  * Mocks imports for the module specified by {@link modulePath}.
  *
@@ -16,8 +25,8 @@
  * @param opt
  * @returns The result of importing {@link modulePath}, similar to `import(modulePath)`.
  */
-declare function esmock(modulePath: string, parent: string, mockDefs?: Record<string, any>, globalDefs?: Record<string, any>, opt?: esmock.Options): any;
-declare function esmock(modulePath: string, mockDefs?: Record<string, any>, globalDefs?: Record<string, any>, opt?: esmock.Options): any;
+declare function esmock(modulePath: string, parent: string, mockDefs?: mocks, globalDefs?: mocks, opt?: opts): any;
+declare function esmock(modulePath: string, mockDefs?: mocks, globalDefs?: mocks, opt?: opts): any;
 
 declare namespace esmock {
   interface Options {
@@ -45,11 +54,11 @@ declare namespace esmock {
    * @param opt
    * @returns The result of importing {@link modulePath}, similar to `import(modulePath)`.
    */
-  function strict(modulePath: string, parent: string, mockDefs?: Record<string, any>, globalDefs?: Record<string, any>, opt?: esmock.Options): any;
-  function strict(modulePath: string, mockDefs?: Record<string, any>, globalDefs?: Record<string, any>, opt?: esmock.Options): any;
+  function strict(modulePath: string, parent: string, mockDefs?: mocks, globalDefs?: mocks, opt?: opts): any;
+  function strict(modulePath: string, mockDefs?: mocks, globalDefs?: mocks, opt?: opts): any;
   export namespace strict {
-    function p(modulePath: string, parent: string, mockDefs?: Record<string, any>, globalDefs?: Record<string, any>, opt?: esmock.Options): any;
-    function p(modulePath: string, mockDefs?: Record<string, any>, globalDefs?: Record<string, any>, opt?: esmock.Options): any;
+    function p(modulePath: string, parent: string, mockDefs?: mocks, globalDefs?: mocks, opt?: opts): any;
+    function p(modulePath: string, mockDefs?: mocks, globalDefs?: mocks, opt?: opts): any;
   }
   /**
    * Mocks dynamic imports for the module specified by {@link modulePath}.
@@ -68,8 +77,8 @@ declare namespace esmock {
    * @param opt
    * @returns The result of importing {@link modulePath}, similar to `import(modulePath)`.
    */
-  function p(modulePath: string, parent: string, mockDefs?: Record<string, any>, globalDefs?: Record<string, any>, opt?: esmock.Options): any;
-  function p(modulePath: string, mockDefs?: Record<string, any>, globalDefs?: Record<string, any>, opt?: esmock.Options): any;    
+  function p(modulePath: string, parent: string, mockDefs?: mocks, globalDefs?: mocks, opt?: opts): any;
+  function p(modulePath: string, mockDefs?: mocks, globalDefs?: mocks, opt?: opts): any;    
 
   /**
    * Unregisters a dynamic mock created by {@link esmock.p}.

--- a/src/esmock.d.ts
+++ b/src/esmock.d.ts
@@ -15,18 +15,14 @@ type opts = {
  *
  * @param modulePath The module whose imports will be mocked.
  * @param parent A URL to resolve specifiers relative to; typically `import.meta.url`.
- *               If not specified, it will be inferred via the stack, which may not work
- *               if source maps are in use.
- * @param mockDefs A mapping of import specifiers to mocked module objects; these mocks will
- *                 only be used for imports resolved in the module specified by {@link modulePath}.
- * @param globalDefs A mapping of import specifiers to mocked module objects; these mocks will
- *                   apply to imports within the module specified by {@link modulePath}, as well
- *                   as any transitively imported modules.
+ *               If not specified, inferred via the stack. Useful with source maps.
+ * @param defs A mapping of import specifiers to mock definitions.
+ * @param gdefs A mapping of import specifiers to mock definitions, applied globally.
  * @param opt
  * @returns The result of importing {@link modulePath}, similar to `import(modulePath)`.
  */
-declare function esmock(modulePath: string, parent: string, mockDefs?: mocks, globalDefs?: mocks, opt?: opts): any;
-declare function esmock(modulePath: string, mockDefs?: mocks, globalDefs?: mocks, opt?: opts): any;
+declare function esmock(modulePath: string, parent: string, defs?: mocks, gdefs?: mocks, opt?: opts): any
+declare function esmock(modulePath: string, defs?: mocks, gdefs?: mocks, opt?: opts): any
 
 declare namespace esmock {
   /**
@@ -37,22 +33,19 @@ declare namespace esmock {
    *
    * @param modulePath The module whose imports will be mocked.
    * @param parent A URL to resolve specifiers relative to; typically `import.meta.url`.
-   *               If not specified, it will be inferred via the stack, which may not work
-   *               if source maps are in use.
-   * @param mockDefs A mapping of import specifiers to mocked module objects; these mocks will
-   *                 only be used for imports resolved in the module specified by {@link modulePath}.
-   * @param globalDefs A mapping of import specifiers to mocked module objects; these mocks will
-   *                   apply to imports within the module specified by {@link modulePath}, as well
-   *                   as any transitively imported modules.
+   *               If not specified, inferred via the stack. Useful with source maps.
+   * @param defs A mapping of import specifiers to mock definitions.
+   * @param gdefs A mapping of import specifiers to mock definitions, applied globally.
    * @param opt
    * @returns The result of importing {@link modulePath}, similar to `import(modulePath)`.
    */
-  function strict(modulePath: string, parent: string, mockDefs?: mocks, globalDefs?: mocks, opt?: opts): any;
-  function strict(modulePath: string, mockDefs?: mocks, globalDefs?: mocks, opt?: opts): any;
+  function strict(modulePath: string, parent: string, defs?: mocks, gdefs?: mocks, opt?: opts): any
+  function strict(modulePath: string, defs?: mocks, gdefs?: mocks, opt?: opts): any
   export namespace strict {
-    function p(modulePath: string, parent: string, mockDefs?: mocks, globalDefs?: mocks, opt?: opts): any;
-    function p(modulePath: string, mockDefs?: mocks, globalDefs?: mocks, opt?: opts): any;
+    function p(modulePath: string, parent: string, defs?: mocks, gdefs?: mocks, opt?: opts): any
+    function p(modulePath: string, defs?: mocks, gdefs?: mocks, opt?: opts): any
   }
+
   /**
    * Mocks dynamic imports for the module specified by {@link modulePath}.
    *
@@ -60,25 +53,21 @@ declare namespace esmock {
    *
    * @param modulePath The module whose imports will be mocked.
    * @param parent A URL to resolve specifiers relative to; typically `import.meta.url`.
-   *               If not specified, it will be inferred via the stack, which may not work
-   *               if source maps are in use.
-   * @param mockDefs A mapping of import specifiers to mocked module objects; these mocks will
-   *                 only be used for imports resolved in the module specified by {@link modulePath}.
-   * @param globalDefs A mapping of import specifiers to mocked module objects; these mocks will
-   *                   apply to imports within the module specified by {@link modulePath}, as well
-   *                   as any transitively imported modules.
+   *               If not specified, inferred via the stack. Useful with source maps.
+   * @param defs A mapping of import specifiers to mock definitions.
+   * @param gdefs A mapping of import specifiers to mock definitions, applied globally.
    * @param opt
    * @returns The result of importing {@link modulePath}, similar to `import(modulePath)`.
    */
-  function p(modulePath: string, parent: string, mockDefs?: mocks, globalDefs?: mocks, opt?: opts): any;
-  function p(modulePath: string, mockDefs?: mocks, globalDefs?: mocks, opt?: opts): any;    
+  function p(modulePath: string, parent: string, defs?: mocks, gdefs?: mocks, opt?: opts): any
+  function p(modulePath: string, defs?: mocks, gdefs?: mocks, opt?: opts): any
 
   /**
    * Unregisters a dynamic mock created by {@link esmock.p}.
    *
    * @param mockModule A module object that was previously returned by {@link esmock.p}.
    */
-  function purge(mockModule: any): void;
+  function purge(mockModule: any): void
 }
 
-export { esmock as default, esmock as strict };
+export { esmock as default, esmock as strict }

--- a/src/esmock.d.ts
+++ b/src/esmock.d.ts
@@ -29,13 +29,6 @@ declare function esmock(modulePath: string, parent: string, mockDefs?: mocks, gl
 declare function esmock(modulePath: string, mockDefs?: mocks, globalDefs?: mocks, opt?: opts): any;
 
 declare namespace esmock {
-  interface Options {
-    strict?: boolean | undefined;
-    purge?: boolean | undefined;
-    isModuleNotFoundError?: boolean | undefined;
-    parent?: string | undefined;
-  }
-
   /**
    * Mocks imports for the module specified by {@link modulePath}.
    *

--- a/src/esmock.d.ts
+++ b/src/esmock.d.ts
@@ -3,15 +3,14 @@ type mocks = Record<string, any>
 type opts = {
   strict?: boolean | undefined,
   purge?: boolean | undefined,
-  isModuleNotFoundError?: boolean | undefined,
-  parent?: string | undefined
+  isModuleNotFoundError?: boolean | undefined
 }
 
 /**
  * Mocks imports for the module specified by {@link modulePath}.
  *
  * By default, mock definitions are merged with the original module definitions.
- * To disable the default behaviour, Use esmock.strict.
+ * To avoid the default behaviour, use esmock.strict.
  *
  * @param modulePath The module whose imports will be mocked.
  * @param parent A URL to resolve specifiers relative to; typically `import.meta.url`.
@@ -28,8 +27,7 @@ declare namespace esmock {
   /**
    * Mocks imports for the module specified by {@link modulePath}.
    *
-   * This "strict" variant gives un-modified mock definitions that are not
-   * merged with original module definitions.
+   * The "strict" variant replaces original module definitions with mock definitions.
    *
    * @param modulePath The module whose imports will be mocked.
    * @param parent A URL to resolve specifiers relative to; typically `import.meta.url`.
@@ -47,7 +45,7 @@ declare namespace esmock {
   }
 
   /**
-   * Mocks dynamic imports for the module specified by {@link modulePath}.
+   * Uses caching to support `await import()` inside the mocked import tree.
    *
    * After using this function, consider calling {@link esmock.purge} to free memory.
    *
@@ -63,9 +61,9 @@ declare namespace esmock {
   function p(modulePath: string, defs?: mocks, gdefs?: mocks, opt?: opts): any
 
   /**
-   * Unregisters a dynamic mock created by {@link esmock.p}.
+   * Removes caching created by {@link esmock.p}.
    *
-   * @param mockModule A module object that was previously returned by {@link esmock.p}.
+   * @param mockModule A module object returned from {@link esmock.p}.
    */
   function purge(mockModule: any): void
 }


### PR DESCRIPTION
[esmock.d.ts][0] basically repeats the same definitions many times, because esmock's main function signature is exported in ways that are foreign to typescript. The various main esmock calls are shown below and they all have the same signature,
```javascript
import esmock, { strict } from 'esmock'

const moduleId = './example.js';
const parent = import.meta.url
const mocks = {}
const globalmocks = {}
const opts = {}

esmock(moduleId, mocks, globalmocks, opts)
esmock(moduleId, parent, mocks, globalmocks, opts)
esmock.p(moduleId, mocks, globalmocks, opts) // persist cache
esmock.p(moduleId, parent, mocks, globalmocks, opts)
strict(moduleId, mocks, globalmocks, opts)
strict(moduleId, parent, mocks, globalmocks, opts)
strict.p(moduleId, mocks, globalmocks, opts) // persist cache
strict.p(moduleId, parent, mocks, globalmocks, opts)
esmock.strict(moduleId, mocks, globalmocks, opts)
esmock.strict(moduleId, parent, mocks, globalmocks, opts)
esmock.strict.p(moduleId, mocks, globalmocks, opts) // persist cache
esmock.strict.p(moduleId, parent, mocks, globalmocks, opts)
```

Searching for a way to re-use one documentation block and/or one esmock function signature, these attempts failed...
 * attempted to use the [inheritdoc](https://tsdoc.org/pages/tags/inheritdoc/) tag, but vscode did not show documentation for functions using inheritdoc,
 * attempted to define esmock function "types", then define those inside an esmock interface (rather than namespace) this didn't work and anyway was unable to export esmock as a "union" of esmock function and esmock interface

[0]: https://github.com/iambumblehead/esmock/blob/master/src/esmock.d.ts