### PR TITLE
small lint-adjustments and remove empty lines

### DIFF
--- a/src/esmock.d.ts
+++ b/src/esmock.d.ts
@@ -6,44 +6,39 @@ type Options = {
   isModuleNotFoundError?: boolean | undefined
 }
 
-/**
- * Mocks imports for the module specified by {@link modulePath}.
- *
- * @param modulePath The module whose imports will be mocked.
- *
- * @param parent A URL used to resolve relative specifiers, typically
- * `import.meta.url`. If not specified, inferred via the stack. Useful with
- * source maps.
- *
- * @param defs A mapping of import specifiers to mock definitions.
- *
- * @param gdefs A globally applied mapping of import specifiers to mock
- * definitions.
- *
- * @param opts
- *
- * @returns The result of importing {@link modulePath}, similar to
- * `import(modulePath)`.
- */
 type MockFunction = {
+  /**
+   * Mocks imports for the module specified by {@link modulePath}.
+   *
+   * @param modulePath The module whose imports will be mocked.
+   * @param parent A URL used to resolve relative specifiers, typically
+   * `import.meta.url`. If not specified, inferred via the stack. Useful with
+   * source maps.
+   * @param defs A mapping of import specifiers to mock definitions.
+   * @param gdefs A globally applied mapping of import specifiers to mock
+   * definitions.
+   * @param opts
+   * @returns The mocked import-tree result of "import({@link modulePath})"
+   */
   (
     modulePath: string,
     parent: string,
     defs?: MockMap,
     gdefs?: MockMap,
-    opts?: Options,
+    opts?: Options
   ): any,
   (
     modulePath: string,
     defs?: MockMap,
     gdefs?: MockMap,
-    opts?: Options,
+    opts?: Options
   ): any
 }
 
 /**
  * By default, mock definitions are merged with the original module definitions.
  * To avoid the default behaviour, use {@link esmock.strict}.
+ *
  */
 declare const esmock: MockFunction & {
   /**


### PR DESCRIPTION
![Screenshot from 2022-09-27 22-13-33](https://user-images.githubusercontent.com/2058705/192696507-967fbc70-1bea-4f12-943d-83202cb565ee.gif)

All documentation appear in vscode's intellisense after one change: documentation above `type MockFunction` was moved to the inside of the `type MockFunction` expression. Because everything is working, `@see` and `@link` tags probably aren't needed.

Earlier this evening, a different PR added ts linting rules so the definitions file would use the same formatting as other src files https://github.com/iambumblehead/esmock/pull/166

closes https://github.com/iambumblehead/esmock/issues/160

cc @jsejcksn to share