### PR TITLE
added support for esmock.strictest

### DIFF
--- a/src/esmock.d.ts
+++ b/src/esmock.d.ts
@@ -62,6 +62,14 @@ declare const esmock: MockFunction & {
   strict: MockFunction & {
     p: MockFunction
   }
+
+  /**
+   * The "strictest" variant replaces original module definitions
+   * with mock definitions AND requires all imported modules to be mocked.
+   */
+  strictest: MockFunction & {
+    p: MockFunction
+  }
 }
 
 /**
@@ -70,9 +78,16 @@ declare const esmock: MockFunction & {
  */
 declare const strict: typeof esmock['strict']
 
+/**
+ * The "strictest" variant replaces original module definitions
+ * with mock definitions AND requires all imported modules to be mocked.
+ */
+declare const strictest: typeof esmock['strictest']
+
 export {
   esmock as default,
   strict,
+  strictest,
   type MockFunction,
   type MockMap,
   type Options

--- a/src/esmock.d.ts
+++ b/src/esmock.d.ts
@@ -61,7 +61,7 @@ declare const esmock: MockFunction & {
    */
   strict: MockFunction & {
     p: MockFunction
-  }
+  },
 
   /**
    * The "strictest" variant replaces original module definitions

--- a/src/esmock.js
+++ b/src/esmock.js
@@ -20,10 +20,13 @@ const purge = mockModule => mockModule
   && /object|function/.test(typeof mockModule) && 'esmkTreeId' in mockModule
   && esmockModule.purge(mockModule.esmkTreeId)
 
-const strict = Object.assign(esmockGo({ strict: true }), {
-  purge, p: esmockGo({ strict: true, purge: false }) })
+const strict = Object.assign(esmockGo({ strict: 1 }), {
+  purge, p: esmockGo({ strict: 1, purge: false }) })
+
+const strictest = Object.assign(esmockGo({ strict: 3 }), {
+  purge, p: esmockGo({ strict: 3, purge: false }) })
 
 const esmock = Object.assign(esmockGo(), {
-  purge, p: esmockGo({ purge: false }), strict })
+  purge, p: esmockGo({ purge: false }), strict, strictest })
 
-export {esmock as default, strict}
+export {esmock as default, strict, strictest}

--- a/src/esmockErr.js
+++ b/src/esmockErr.js
@@ -1,0 +1,15 @@
+const narrow = p => p
+  .replace('file://', '')
+  .replace(process.cwd(), '.')
+  .replace(process.env.HOME, '~')
+
+const errModuleIdNotFound = (moduleId, parent) => new Error(
+  `invalid moduleId: "${narrow(moduleId)}" (used by ${narrow(parent)})`)
+
+const errModuleIdNotMocked = (moduleId, parent) => new Error(
+  `un-mocked moduleId: "${narrow(moduleId)}" (used by ${narrow(parent)})`)
+
+export default {
+  errModuleIdNotFound,
+  errModuleIdNotMocked
+}

--- a/src/esmockLoader.js
+++ b/src/esmockLoader.js
@@ -1,5 +1,6 @@
 import process from 'process'
 import urlDummy from './esmockDummy.js'
+import esmockErr from './esmockErr.js'
 
 const [major, minor] = process.versions.node.split('.').map(it => +it)
 const isLT1612 = major < 16 || (major === 16 && minor < 12)
@@ -72,6 +73,9 @@ const resolve = async (specifier, context, nextResolve) => {
       resolved.url += '?esmkgdefs=' + gdefs
     }
   }
+
+  if (/strict=3/.test(treeidspec) && !moduleId)
+    throw esmockErr.errModuleIdNotMocked(resolvedurl, treeidspec.split('?')[0])
 
   return resolved
 }

--- a/tests/local/importsCoreLocalAndPackage.js
+++ b/tests/local/importsCoreLocalAndPackage.js
@@ -1,0 +1,7 @@
+import core from 'path'
+import local from './usesCoreModule.js'
+import pkg from 'form-urlencoded'
+
+export const corePathBasename = p => core.basename(p)
+export const localReadSync = p => local.readPath(p)
+export const packageFn = p => pkg(p)

--- a/tests/tests-node/esmock.node.test.js
+++ b/tests/tests-node/esmock.node.test.js
@@ -472,7 +472,6 @@ test('should error when "strictest" mock tree module not mocked', async () => {
         .replace(':parent', 'importsCoreLocalAndPackage.js'))
   })
 
-
   await assert.rejects(async () => esmock.strictest(
     '../local/importsCoreLocalAndPackage.js', {
       path: { basename: () => 'core' },

--- a/tests/tests-node/esmock.node.test.js
+++ b/tests/tests-node/esmock.node.test.js
@@ -434,3 +434,55 @@ test('should throw error when strict mock definition not found', async () => {
   assert.deepEqual(pathWrapPartial.basename('/dog.png'), 'dog.png')
 })
 
+test('should error when "strictest" mock tree module not mocked', async () => {
+  const strictestTree = await esmock.strictest(
+    '../local/importsCoreLocalAndPackage.js', {
+      path: { basename: () => 'core' },
+      '../local/usesCoreModule.js': { readPath: () => 'local' },
+      'form-urlencoded': () => 'package'
+    }
+  )
+
+  assert.deepEqual(strictestTree.corePathBasename(), 'core')
+  assert.deepEqual(strictestTree.localReadSync(), 'local')
+  assert.deepEqual(strictestTree.packageFn(), 'package')
+
+  await assert.rejects(async () => esmock.strictest(
+    '../local/importsCoreLocalAndPackage.js', {
+      '../local/usesCoreModule.js': { readPath: () => 'local' },
+      'form-urlencoded': () => 'package'
+    }
+  ), {
+    name: 'Error',
+    message: new RegExp(
+      'un-mocked moduleId: "node:path" \\(used by .*:parent\\)'
+        .replace(':parent', 'importsCoreLocalAndPackage.js'))
+  })
+
+  await assert.rejects(async () => esmock.strictest(
+    '../local/importsCoreLocalAndPackage.js', {
+      path: { basename: () => 'core' },
+      'form-urlencoded': () => 'package'
+    }
+  ), {
+    name: 'Error',
+    message: new RegExp(
+      'un-mocked moduleId: ".*:child" \\(used by .*:parent\\)'
+        .replace(':child', 'usesCoreModule.js')
+        .replace(':parent', 'importsCoreLocalAndPackage.js'))
+  })
+
+
+  await assert.rejects(async () => esmock.strictest(
+    '../local/importsCoreLocalAndPackage.js', {
+      path: { basename: () => 'core' },
+      '../local/usesCoreModule.js': { readPath: () => 'local' },
+    }
+  ), {
+    name: 'Error',
+    message: new RegExp(
+      'un-mocked moduleId: ".*:package" \\(used by .*:parent\\)'
+        .replace(':package', 'form-urlencoded.mjs')
+        .replace(':parent', 'importsCoreLocalAndPackage.js'))
+  })
+})

--- a/tests/tests-node/esmock.node.test.js
+++ b/tests/tests-node/esmock.node.test.js
@@ -476,7 +476,7 @@ test('should error when "strictest" mock tree module not mocked', async () => {
   await assert.rejects(async () => esmock.strictest(
     '../local/importsCoreLocalAndPackage.js', {
       path: { basename: () => 'core' },
-      '../local/usesCoreModule.js': { readPath: () => 'local' },
+      '../local/usesCoreModule.js': { readPath: () => 'local' }
     }
   ), {
     name: 'Error',


### PR DESCRIPTION
adds support for a stricter variant of esmock, per @gmahomarf  https://github.com/iambumblehead/esmock/issues/171

At the time this PR is created, here's what is added. esmock exports a new 'strictest' variant and when an imported module is not not mocked for the strictest import tree, esmock throws a runtime error like this,
```console
"un-mocked moduleId: '~/root/child.js' (used by ~/root/parent.js)"
```

closes https://github.com/iambumblehead/esmock/issues/171