### PR TITLE
add test script variants using --experimental-import-meta-resolve

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 6
+    timeout-minutes: 12
     strategy:
       matrix:
         node-version: [14.x, 16.x, 18.x]

--- a/src/esmockModule.js
+++ b/src/esmockModule.js
@@ -16,9 +16,8 @@ const isDirPathRe = /^\.?\.?([a-zA-Z]:)?(\/|\\)/
 const isMetaResolve = typeof import.meta.resolve === 'function'
 const nextId = ((id = 0) => () => ++id)()
 const rootDirSlashRe = /^\//
-const protocolFileRe = /^file:/
 
-const asFileURL = p => protocolFileRe.test(p) ? p
+const asFileURL = p => p.startsWith('file:') ? p
   : `file:///${p.replace(rootDirSlashRe, '')}`
 
 const esmockModuleMergeDefault = (defLive, def) =>

--- a/src/esmockModule.js
+++ b/src/esmockModule.js
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import url from 'node:url'
 import resolvewith from 'resolvewithplus'
 import esmockErr from './esmockErr.js'
 
@@ -16,9 +17,7 @@ const isDirPathRe = /^\.?\.?([a-zA-Z]:)?(\/|\\)/
 const isMetaResolve = typeof import.meta.resolve === 'function'
 const nextId = ((id = 0) => () => ++id)()
 const rootDirSlashRe = /^\//
-
-const asFileURL = p => p.startsWith('file://') ? p
-  : `file:///${p.replace(rootDirSlashRe, '')}`
+const asFileURL = p => p.startsWith('file://') ? p : url.pathToFileURL(p)
 
 const esmockModuleMergeDefault = (defLive, def) =>
   (isObj(defLive) && isObj(def)) ? Object.assign({}, defLive, def) : def

--- a/src/esmockModule.js
+++ b/src/esmockModule.js
@@ -101,7 +101,7 @@ const esmockModuleCreate = async (treeid, def, id, fileURL, opt) => {
 const esmockMetaResolve = async (id, parent) => {
   try {
     return decodeURI(await import.meta.resolve(id, asFileURL(parent)))
-  } catch (e) {
+  } catch {
     return null
   }
 }

--- a/src/esmockModule.js
+++ b/src/esmockModule.js
@@ -17,7 +17,7 @@ const isMetaResolve = typeof import.meta.resolve === 'function'
 const nextId = ((id = 0) => () => ++id)()
 const rootDirSlashRe = /^\//
 
-const asFileURL = p => p.startsWith('file:') ? p
+const asFileURL = p => p.startsWith('file://') ? p
   : `file:///${p.replace(rootDirSlashRe, '')}`
 
 const esmockModuleMergeDefault = (defLive, def) =>

--- a/src/esmockModule.js
+++ b/src/esmockModule.js
@@ -13,7 +13,13 @@ import {
 const isObj = o => typeof o === 'object' && o
 const isDefaultIn = o => isObj(o) && 'default' in o
 const isDirPathRe = /^\.?\.?([a-zA-Z]:)?(\/|\\)/
+const isMetaResolve = typeof import.meta.resolve === 'function'
 const nextId = ((id = 0) => () => ++id)()
+const rootDirSlashRe = /^\//
+const protocolFileRe = /^file:/
+
+const asFileURL = p => protocolFileRe.test(p) ? p
+  : `file:///${p.replace(rootDirSlashRe, '')}`
 
 const esmockModuleMergeDefault = (defLive, def) =>
   (isObj(defLive) && isObj(def)) ? Object.assign({}, defLive, def) : def
@@ -92,6 +98,14 @@ const esmockModuleCreate = async (treeid, def, id, fileURL, opt) => {
   return mockModuleKey
 }
 
+const esmockMetaResolve = async (id, parent) => {
+  try {
+    return decodeURI(await import.meta.resolve(id, asFileURL(parent)))
+  } catch (e) {
+    return null
+  }
+}
+
 const esmockModuleId = async (parent, treeid, defs, ids, opt, mocks, id) => {
   ids = ids || Object.keys(defs)
   id = ids[0]
@@ -99,7 +113,9 @@ const esmockModuleId = async (parent, treeid, defs, ids, opt, mocks, id) => {
 
   if (!id) return mocks
 
-  const fileURL = resolvewith(id, parent)
+  const fileURL = isMetaResolve
+    ? await esmockMetaResolve(id, parent)
+    : resolvewith(id, parent)
   if (!fileURL && opt.isModuleNotFoundError !== false)
     throw esmockErr.errModuleIdNotFound(id, parent)
 

--- a/src/esmockModule.js
+++ b/src/esmockModule.js
@@ -16,7 +16,6 @@ const isDefaultIn = o => isObj(o) && 'default' in o
 const isDirPathRe = /^\.?\.?([a-zA-Z]:)?(\/|\\)/
 const isMetaResolve = typeof import.meta.resolve === 'function'
 const nextId = ((id = 0) => () => ++id)()
-const rootDirSlashRe = /^\//
 const asFileURL = p => p.startsWith('file://') ? p : url.pathToFileURL(p)
 
 const esmockModuleMergeDefault = (defLive, def) =>

--- a/tests/tests-jest-ts/package.json
+++ b/tests/tests-jest-ts/package.json
@@ -20,8 +20,12 @@
     "runner": "jest-light-runner"
   },
   "scripts": {
-    "test:default": "NODE_OPTIONS=\"--loader=ts-node/esm --loader=esmock\" jest esmock.node-jest.test.ts",
-    "test:win32": "set \"NODE_OPTIONS=--loader=ts-node/esm --loader=esmock\" && jest esmock.node-jest.test.ts",
+    "test:default-metaresolve": "NODE_OPTIONS=\"--experimental-import-meta-resolve --loader=ts-node/esm --loader=esmock\" jest esmock.node-jest.test.ts",
+    "test:default-nometaresolve": "NODE_OPTIONS=\"--loader=ts-node/esm --loader=esmock\" jest esmock.node-jest.test.ts",
+    "test:default": "npm run test:default-metaresolve && npm run test:default-nometaresolve",
+    "test:win32-metaresolve": "set \"NODE_OPTIONS=--experimental-import-meta-resolve --loader=ts-node/esm --loader=esmock\" && jest esmock.node-jest.test.ts",
+    "test:win32-nometaresolve": "set \"NODE_OPTIONS=--loader=ts-node/esm --loader=esmock\" && jest esmock.node-jest.test.ts",
+    "test:win32": "npm run test:win32-metaresolve && npm run test:win32-nometaresolve",
     "test": "run-script-os"
   }
 }

--- a/tests/tests-jest/package.json
+++ b/tests/tests-jest/package.json
@@ -19,8 +19,12 @@
     "runner": "jest-light-runner"
   },
   "scripts": {
-    "test:default": "NODE_OPTIONS=--loader=esmock jest",
-    "test:win32": "set NODE_OPTIONS=--loader=esmock && jest",
+    "test:default-metaresolve": "NODE_OPTIONS=\"--experimental-import-meta-resolve --loader=esmock\" jest",
+    "test:default-nometaresolve": "NODE_OPTIONS=--loader=esmock jest",
+    "test:default": "npm run test:default-metaresolve && npm run test:default-nometaresolve",
+    "test:win32-metaresolve": "set \"NODE_OPTIONS=--experimental-import-meta-resolve --loader=esmock\" && jest",
+    "test:win32-nometaresolve": "set NODE_OPTIONS=--loader=esmock && jest",
+    "test:win32": "npm run test:win32-metaresolve && npm run test:win32-metaresolve",
     "test": "run-script-os"
   }
 }

--- a/tests/tests-node/package.json
+++ b/tests/tests-node/package.json
@@ -13,6 +13,7 @@
     "babelGeneratedDoubleDefault": "file:../local/babelGeneratedDoubleDefault"
   },
   "scripts": {
-    "test": "node --loader=esmock --test"
+    "test:metaresolve": "node --experimental-import-meta-resolve --loader=esmock --test",
+    "test": "node --loader=esmock --test && npm run test:metaresolve"
   }
 }

--- a/tests/tests-nodets/package.json
+++ b/tests/tests-nodets/package.json
@@ -14,6 +14,8 @@
     "babelGeneratedDoubleDefault": "file:../local/babelGeneratedDoubleDefault"
   },
   "scripts": {
-    "test": "node --loader=ts-node/esm --loader=esmock --test esmock.node-ts.test.ts esmock.node-ts.importing.test.ts"
+    "test-metaresolve": "node --experimental-import-meta-resolve --loader=ts-node/esm --loader=esmock --test esmock.node-ts.test.ts esmock.node-ts.importing.test.ts",
+    "test-nometaresolve": "node --loader=ts-node/esm --loader=esmock --test esmock.node-ts.test.ts esmock.node-ts.importing.test.ts",
+    "test": "npm run test-metaresolve && npm run test-nometaresolve"
   }
 }

--- a/tests/tests-source-map/package.json
+++ b/tests/tests-source-map/package.json
@@ -16,7 +16,9 @@
     "typescript": "^4.8.3"
   },
   "scripts": {
-    "test": "rimraf dist && tsc && cross-env NODE_OPTIONS=--loader=esmock NODE_NO_WARNINGS=1 ava",
+    "test-metaresolve": "rimraf dist && tsc && cross-env \"NODE_OPTIONS=--experimental-import-meta-resolve --loader=esmock\" NODE_NO_WARNINGS=1 ava",
+    "test-nometaresolve": "rimraf dist && tsc && cross-env NODE_OPTIONS=--loader=esmock NODE_NO_WARNINGS=1 ava",
+    "test": "npm run test-metaresolve && npm run test-nometaresolve",
     "test-no-maps": "rimraf dist && tsc --sourceMap false && cross-env NODE_OPTIONS=--loader=esmock NODE_NO_WARNINGS=1 ava"
   },
   "ava": {

--- a/tests/tests-tsm/package.json
+++ b/tests/tests-tsm/package.json
@@ -15,6 +15,8 @@
     "babelGeneratedDoubleDefault": "file:../local/babelGeneratedDoubleDefault"
   },
   "scripts": {
-    "test": "node --loader=tsm --loader=esmock --test esmock.node-tsm.test.ts"
+    "test:metaresolve": "node --experimental-import-meta-resolve --loader=tsm --loader=esmock --test esmock.node-tsm.test.ts",
+    "test:nometaresolve": "node --loader=tsm --loader=esmock --test esmock.node-tsm.test.ts",
+    "test": "npm run test:metaresolve && npm run test:nometaresolve"
   }
 }


### PR DESCRIPTION
for tests that run in node18 _(tsm, node, jest, jest-ts, node-ts and source-map)_ run each tests twice,
 1. one time using --experimental-import-meta-resolve, to test esmock with import.meta.resolve,
 2. second time without --experimental-import-meta-resolve, to test esmock with resolvewithplus

changes added to support import.meta.resolve,
 * parent urls are converted to fileURL when they are passed to import.meta.resolve. eg, "/path/to/parent" is converted to 'file:///path/to/parent'
 * values returned by import.meta.resolve are decoded with decodeURI, so that white%20space and other encodings are removed (without decodeURI, tests fail)