### PR TITLE
embed resolvewithplus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # changelog
 
- * 2.0.7 _Oct.??.2022_
+ * 2.0.7 _Oct.20.2022_
+   * [embed resolvewithplus inside esmock,](https://github.com/iambumblehead/esmock/pull/181) to support yarn PnP, per @koshic
    * [use loader mechanism to detect](https://github.com/iambumblehead/esmock/pull/180) presence of esmock loader
    * [detect and use import.meta.resolve,](https://github.com/iambumblehead/esmock/pull/179) when defined by host environment
  * 2.0.6 _Oct.14.2022_

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "test-cover": "npm run test:install && c8 npm run test:all",
     "lint": "eslint --ext=.js,.mjs .",
     "lint-fix": "eslint --ext=.js,.mjs --fix .",
-    "mini:pkg": "npm pkg delete scripts devDependencies",
+    "mini:pkg": "npm pkg delete scripts devDependencies dependencies",
     "prepublishOnly": "npm run lint && npm run test-ci && npm run mini:pkg"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esmock",
   "type": "module",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "license": "ISC",
   "readmeFilename": "README.md",
   "description": "provides native ESM import mocking for unit tests",

--- a/src/esmockCache.js
+++ b/src/esmockCache.js
@@ -13,10 +13,10 @@ const esmockTreeIdGet = key => (
   global.mockKeys[String(key)])
 
 const esmockCacheSet = (key, mockDef) => (
-  esmockCache.mockDefs[key] = mockDef)
+  global.esmockCache.mockDefs[key] = mockDef)
 
 const esmockCacheGet = key => (
-  esmockCache.mockDefs[key])
+  global.esmockCache.mockDefs[key])
 
 const esmockCacheResolvedPathIsESMGet = mockPathFull => (
   esmockCache.isESM[mockPathFull])
@@ -25,6 +25,7 @@ const esmockCacheResolvedPathIsESMSet = (mockPathFull, isesm) => (
   esmockCache.isESM[mockPathFull] = isesm)
 
 Object.assign(global, {
+  esmockCache,
   esmockCacheGet,
   esmockTreeIdGet,
   mockKeys: {}

--- a/tests/package.json
+++ b/tests/package.json
@@ -48,7 +48,7 @@
     "test:node18-test-no-loader": "cd tests-no-loader && npm test",
     "test:node18:all": "npm run isnodelt18 || npm-run-all test:node18-test*",
     "test:all": "npm-run-all test:test* && npm run test:node18:all",
-    "test:all-cover": "c8 --src=../src/esmock* npm run test:all",
+    "test:all-cover": "c8 --src=../src/esmockLoader* npm run test:all",
     "test:all-ci": "npm run mini && npm run test:all"
   }
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -27,6 +27,9 @@
     "mini:default": "cd .. && npx esbuild ./src/*js --minify --allow-overwrite --outdir=src",
     "mini:win32": "cd .. && cd src && forfiles /m \"*.js\" /c \"cmd /c npx esbuild @file --minify --allow-overwrite --outfile=@file\"",
     "mini": "run-script-os",
+    "embed:cp-refd": "node --input-type=module -e \"import fs from 'fs';fs.copyFileSync('../node_modules/resolvewithplus/resolvewithplus.js', '../src/resolvewithplus.js')\"",
+    "embed:update-refs": "node --input-type=module -e \"import fs from 'fs';let p='../src/esmockModule.js';fs.writeFileSync(p, fs.readFileSync(p, 'utf-8').replace(/'resolvewithplus'/, '\\'./resolvewithplus.js\\''))\"",
+    "embed": "npm run embed:update-refs && npm run embed:cp-refd",
     "isnodelt18": "node -e \"+process.versions.node.split('.')[0] < 18 || process.exit(1)\"",
     "install:esmock": "cd .. && npm install",
     "install:test-ava": "cd tests-ava && npm install",
@@ -50,7 +53,7 @@
     "test:node18-test-no-loader": "cd tests-no-loader && npm test",
     "test:node18:all": "npm run isnodelt18 || npm-run-all test:node18-test*",
     "test:all": "npm-run-all test:test* && npm run test:node18:all",
-    "test:all-cover": "c8 --src=../src/* npm run test:all",
-    "test:all-ci": "npm run mini && npm run test:all"
+    "test:all-cover": "c8 --src=../src/esmock* npm run test:all",
+    "test:all-ci": "npm run mini && npm run embed && npm run test:all"
   }
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -48,7 +48,7 @@
     "test:node18-test-no-loader": "cd tests-no-loader && npm test",
     "test:node18:all": "npm run isnodelt18 || npm-run-all test:node18-test*",
     "test:all": "npm-run-all test:test* && npm run test:node18:all",
-    "test:all-cover": "c8 --src=../src/esmockLoader* npm run test:all",
+    "test:all-cover": "c8 --src=../src/* npm run test:all",
     "test:all-ci": "npm run mini && npm run test:all"
   }
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -24,12 +24,7 @@
     "babelGeneratedDoubleDefault": "file:./local/babelGeneratedDoubleDefault"
   },
   "scripts": {
-    "mini:default": "cd .. && npx esbuild ./src/*js --minify --allow-overwrite --outdir=src",
-    "mini:win32": "cd .. && cd src && forfiles /m \"*.js\" /c \"cmd /c npx esbuild @file --minify --allow-overwrite --outfile=@file\"",
-    "mini": "run-script-os",
-    "embed:cp-refd": "node --input-type=module -e \"import fs from 'fs';fs.copyFileSync('../node_modules/resolvewithplus/resolvewithplus.js', '../src/resolvewithplus.js')\"",
-    "embed:update-refs": "node --input-type=module -e \"import fs from 'fs';let p='../src/esmockModule.js';fs.writeFileSync(p, fs.readFileSync(p, 'utf-8').replace(/'resolvewithplus'/, '\\'./resolvewithplus.js\\''))\"",
-    "embed": "npm run embed:update-refs && npm run embed:cp-refd",
+    "mini": "cd .. && cd src && npx esbuild esmockLoader.js --minify --bundle --allow-overwrite --platform=node --format=esm --outfile=esmockLoader.js",
     "isnodelt18": "node -e \"+process.versions.node.split('.')[0] < 18 || process.exit(1)\"",
     "install:esmock": "cd .. && npm install",
     "install:test-ava": "cd tests-ava && npm install",
@@ -54,6 +49,6 @@
     "test:node18:all": "npm run isnodelt18 || npm-run-all test:node18-test*",
     "test:all": "npm-run-all test:test* && npm run test:node18:all",
     "test:all-cover": "c8 --src=../src/esmock* npm run test:all",
-    "test:all-ci": "npm run mini && npm run embed && npm run test:all"
+    "test:all-ci": "npm run mini && npm run test:all"
   }
 }

--- a/tests/tests-node/esmock.node.test.js
+++ b/tests/tests-node/esmock.node.test.js
@@ -4,7 +4,7 @@ import assert from 'node:assert/strict'
 import esmock from 'esmock'
 import sinon from 'sinon'
 import esmockCache from '../../src/esmockCache.js'
-/*
+
 test('should mock package, even when package is not installed', async () => {
   const component = await esmock(`../local/notinstalledVueComponent.js`, {
     vue: {
@@ -261,7 +261,7 @@ test('should mock an exported constant values', async () => {
 
   assert.strictEqual(main.verifyImportedConstant(), 'hello world')
 })
-*/
+
 test('should mock core module', async () => {
   const usesCoreModule = await esmock('../local/usesCoreModule.js', {
     fs: {
@@ -274,7 +274,7 @@ test('should mock core module', async () => {
 
   assert.strictEqual(usesCoreModule.readPath('checkfilepath.js'), 'success')
 })
-/*
+
 test('should apply third parameter "global" definitions', async () => {
   const main = await esmock('../local/main.js', {
     '../local/mainUtil.js': {
@@ -485,4 +485,3 @@ test('should error when "strictest" mock tree module not mocked', async () => {
         .replace(':parent', 'importsCoreLocalAndPackage.js'))
   })
 })
-*/

--- a/tests/tests-node/esmock.node.test.js
+++ b/tests/tests-node/esmock.node.test.js
@@ -4,7 +4,7 @@ import assert from 'node:assert/strict'
 import esmock from 'esmock'
 import sinon from 'sinon'
 import esmockCache from '../../src/esmockCache.js'
-
+/*
 test('should mock package, even when package is not installed', async () => {
   const component = await esmock(`../local/notinstalledVueComponent.js`, {
     vue: {
@@ -261,7 +261,7 @@ test('should mock an exported constant values', async () => {
 
   assert.strictEqual(main.verifyImportedConstant(), 'hello world')
 })
-
+*/
 test('should mock core module', async () => {
   const usesCoreModule = await esmock('../local/usesCoreModule.js', {
     fs: {
@@ -274,7 +274,7 @@ test('should mock core module', async () => {
 
   assert.strictEqual(usesCoreModule.readPath('checkfilepath.js'), 'success')
 })
-
+/*
 test('should apply third parameter "global" definitions', async () => {
   const main = await esmock('../local/main.js', {
     '../local/mainUtil.js': {
@@ -485,3 +485,4 @@ test('should error when "strictest" mock tree module not mocked', async () => {
         .replace(':parent', 'importsCoreLocalAndPackage.js'))
   })
 })
+*/


### PR DESCRIPTION
This PR embeds resolvewithplus inside the esmock package. To test the embedded result in windows-latest ci eval'd node scripts were used rather than `sed` and `cp` commands.