### PR TITLE
use latest resolvewithplus

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "node": ">=14.16.0"
   },
   "dependencies": {
-    "resolvewithplus": "^1.0.2"
+    "resolvewithplus": "^2.0.0"
   },
   "devDependencies": {
     "c8": "^7.12.0",

--- a/src/esmockLoader.js
+++ b/src/esmockLoader.js
@@ -58,9 +58,8 @@ const resolve = async (specifier, context, nextResolve) => {
   }
 
   const resolved = await nextResolveCall(nextResolve, specifier, context)
-  const resolvedurl = decodeURI(resolved.url)
   const moduleIdRe = new RegExp(
-    '.*(' + resolvedurl + '\\?' + treeid + '(?:(?!#-#).)*).*')
+    '.*(' + resolved.url + '\\?' + treeid + '(?:(?!#-#).)*).*')
   const moduleId =
     moduleIdRe.test(defs) && defs.replace(moduleIdRe, '$1') ||
     moduleIdRe.test(gdefs) && gdefs.replace(moduleIdRe, '$1')
@@ -75,7 +74,7 @@ const resolve = async (specifier, context, nextResolve) => {
   }
 
   if (/strict=3/.test(treeidspec) && !moduleId)
-    throw esmockErr.errModuleIdNotMocked(resolvedurl, treeidspec.split('?')[0])
+    throw esmockErr.errModuleIdNotMocked(resolved.url, treeidspec.split('?')[0])
 
   return resolved
 }

--- a/src/esmockModule.js
+++ b/src/esmockModule.js
@@ -95,12 +95,12 @@ const esmockModuleCreate = async (treeid, def, id, fileURL, opt) => {
   return mockModuleKey
 }
 
-const esmockMetaResolve = async (id, parent) => {
-  try {
-    return decodeURI(await import.meta.resolve(id, asFileURL(parent)))
-  } catch {
-    return null
-  }
+const esmockMetaResolve = async (id, parent, p) => {
+  p = isMetaResolve
+    ? await import.meta.resolve(id, asFileURL(parent)).catch(() => p)
+    : resolvewith(id, parent)
+
+  return p && decodeURI(p)
 }
 
 const esmockModuleId = async (parent, treeid, defs, ids, opt, mocks, id) => {
@@ -110,9 +110,7 @@ const esmockModuleId = async (parent, treeid, defs, ids, opt, mocks, id) => {
 
   if (!id) return mocks
 
-  const fileURL = isMetaResolve
-    ? await esmockMetaResolve(id, parent)
-    : resolvewith(id, parent)
+  const fileURL = await esmockMetaResolve(id, parent)
   if (!fileURL && opt.isModuleNotFoundError !== false)
     throw esmockErr.errModuleIdNotFound(id, parent)
 

--- a/src/esmockModule.js
+++ b/src/esmockModule.js
@@ -95,14 +95,6 @@ const esmockModuleCreate = async (treeid, def, id, fileURL, opt) => {
   return mockModuleKey
 }
 
-const esmockMetaResolve = async (id, parent, p) => {
-  p = isMetaResolve
-    ? await import.meta.resolve(id, asFileURL(parent)).catch(() => p)
-    : resolvewith(id, parent)
-
-  return p && decodeURI(p)
-}
-
 const esmockModuleId = async (parent, treeid, defs, ids, opt, mocks, id) => {
   ids = ids || Object.keys(defs)
   id = ids[0]
@@ -110,7 +102,9 @@ const esmockModuleId = async (parent, treeid, defs, ids, opt, mocks, id) => {
 
   if (!id) return mocks
 
-  const fileURL = await esmockMetaResolve(id, parent)
+  const fileURL = isMetaResolve
+    ? await import.meta.resolve(id, asFileURL(parent)).catch(() => null)
+    : resolvewith(id, parent)
   if (!fileURL && opt.isModuleNotFoundError !== false)
     throw esmockErr.errModuleIdNotFound(id, parent)
 

--- a/tests/tests-node/package.json
+++ b/tests/tests-node/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "test:metaresolve": "node --experimental-import-meta-resolve --loader=esmock --test",
-    "test": "node --loader=esmock --test && npm run test:metaresolve"
+    "test": "node --loader=esmock --test && npm run test:metaresolve",
+    "test-one": "node --loader=esmock --test"
   }
 }


### PR DESCRIPTION
using the new resolvewithplus allows decodeURI to be removed from the loader file as well. the ["path with space"](https://github.com/iambumblehead/esmock/blob/master/tests/tests-node/esmock.node.test.js#L386-L394) test is passing here.

please review @aladdin-add @tripodsan 