### PR TITLE
Use export esmock.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # changelog
 
- * 2.0.7 _Oct.20.2022_
+ * 2.0.7 _Oct.26.2022_
+   * [use export esmock.js,](https://github.com/iambumblehead/esmock/pull/182) rather than esmockLoader.js, as main package export
    * [embed resolvewithplus inside esmock,](https://github.com/iambumblehead/esmock/pull/181) to support yarn PnP, per @koshic
    * [use loader mechanism to detect](https://github.com/iambumblehead/esmock/pull/180) presence of esmock loader
    * [detect and use import.meta.resolve,](https://github.com/iambumblehead/esmock/pull/179) when defined by host environment

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "readmeFilename": "README.md",
   "description": "provides native ESM import mocking for unit tests",
   "author": "chris <chris@bumblehead.com>",
-  "main": "./src/esmockLoader.js",
+  "main": "./src/esmock.js",
   "exports": {
     "types": "./src/esmock.d.ts",
-    "import": "./src/esmockLoader.js"
+    "import": "./src/esmock.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,8 @@
     "lint": "eslint --ext=.js,.mjs .",
     "lint-fix": "eslint --ext=.js,.mjs --fix .",
     "mini:pkg": "npm pkg delete scripts devDependencies dependencies",
-    "prepublishOnly": "npm run lint && npm run test-ci && npm run mini:pkg"
+    "mini:src": "cd src && npx rimraf \"!(esmock).js\"",
+    "mini": "npm run mini:pkg && npm run mini:src",
+    "prepublishOnly": "npm run lint && npm run test-ci && npm run mini"
   }
 }

--- a/src/esmock.js
+++ b/src/esmock.js
@@ -31,3 +31,4 @@ const esmock = Object.assign(esmockGo(), {
   purge, p: esmockGo({ purge: false }), strict, strictest })
 
 export {esmock as default, strict, strictest}
+export * from './esmockLoader.js'

--- a/src/esmockLoader.js
+++ b/src/esmockLoader.js
@@ -123,6 +123,4 @@ const load = async (url, context, nextLoad) => {
 // node lt 16.12 require getSource, node gte 16.12 warn remove getSource
 const getSource = isLT1612 && load
 
-export * from './esmock.js'
-export {default} from './esmock.js'
 export {load, resolve, getSource, loaderIsVerified}

--- a/tests/package.json
+++ b/tests/package.json
@@ -24,7 +24,7 @@
     "babelGeneratedDoubleDefault": "file:./local/babelGeneratedDoubleDefault"
   },
   "scripts": {
-    "mini": "cd .. && cd src && npx esbuild esmockLoader.js --minify --bundle --allow-overwrite --platform=node --format=esm --outfile=esmockLoader.js",
+    "mini": "cd .. && cd src && npx esbuild esmock.js --minify --bundle --allow-overwrite --platform=node --format=esm --outfile=esmock.js",
     "isnodelt18": "node -e \"+process.versions.node.split('.')[0] < 18 || process.exit(1)\"",
     "install:esmock": "cd .. && npm install",
     "install:test-ava": "cd tests-ava && npm install",

--- a/tests/package.json.esmock.export.js
+++ b/tests/package.json.esmock.export.js
@@ -1,5 +1,5 @@
-export * from '../src/esmockLoader.js'
-export {default} from '../src/esmockLoader.js'
+export * from '../src/esmock.js'
+export {default} from '../src/esmock.js'
 
 // this file is used in tandem with two other things,
 //


### PR DESCRIPTION
This PR changes the exported file to `esmock.js`, from `esmockLoader.js`. Also, a prepublishing script is added to remove scripts from the src directory, leaving `esmock.js` and `esmock.d.ts`. The published src directory would look like this,
```console
src/
├── esmock.d.ts
└── esmock.js
```
please review @tripodsan @aladdin-add. If you approve, I could merge and publish sometime tomorrow.