### PR TITLE
Add failing test when using `import` with a hashbang

### DIFF
--- a/tests/local/hashbang.js
+++ b/tests/local/hashbang.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import { TESTCONSTANT } from './env.js'
+
+console.log(TESTCONSTANT)

--- a/tests/tests-node/esmock.node.global.test.js
+++ b/tests/tests-node/esmock.node.global.test.js
@@ -50,3 +50,16 @@ test('should mock fetch as shown in README', async () => {
 
   assert.strictEqual(await reqUsers(), '[["jim😄",1],["jen😊",2}]')
 })
+
+test('should mock files with hashbangs', async () => {
+  const logs = []
+
+  await esmock('../local/hashbang.js', {
+    '../local/env.js': { TESTCONSTANT: 'foo' },
+    import: {
+      console: { log: (...args) => logs.push(...args) }
+    }
+  })
+
+  assert.deepEqual(logs, ['foo'])
+})


### PR DESCRIPTION
Ref: #215

Not sure how to mark a test as failing with the Node test runner.