### PR TITLE
do not error when processing sources that include node hashbang

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         # node-14's npm must be updated, but no longer updatable due to:
         #   https://github.com/npm/cli/issues/2663
         # because of this, node-14 test strategy is removed :(
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [16.x, 18.16.x, 20.x]
         os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # changelog
 
  * 2.3.3 _Jul.27.2023_
-   * [do not error when processing node hashbang](https://github.com/iambumblehead/esmock/pull/214) scripts from @tommy-mitchell
+   * [do not error when processing node hashbang](https://github.com/iambumblehead/esmock/pull/217) scripts from @tommy-mitchell
  * 2.3.2 _Jul.22.2023_
    * [restore ava unit-test](https://github.com/iambumblehead/esmock/pull/213) process at node20 test pipeline
    * [investigate problems](https://github.com/iambumblehead/esmock/issues/209) using tsx from @tommy-mitchell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # changelog
 
+ * 2.3.3 _Jul.27.2023_
+   * [do not error when processing node hashbang](https://github.com/iambumblehead/esmock/pull/214) scripts from @tommy-mitchell
  * 2.3.2 _Jul.22.2023_
    * [restore ava unit-test](https://github.com/iambumblehead/esmock/pull/213) process at node20 test pipeline
    * [investigate problems](https://github.com/iambumblehead/esmock/issues/209) using tsx from @tommy-mitchell

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esmock",
   "type": "module",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "license": "ISC",
   "readmeFilename": "README.md",
   "description": "provides native ESM import and globals mocking for unit tests",

--- a/src/esmockLoader.js
+++ b/src/esmockLoader.js
@@ -18,7 +18,7 @@ const exportNamesRe = /.*exportNames=(.*)/
 const withHashRe = /.*#-#/
 const isesmRe = /isesm=true/
 const isnotfoundRe = /isfound=false/
-const hashbangRe = /^(#![^\n]*[\n])/
+const hashbangRe = /^(#![^\n]*\n)/
 
 const globalPreload = (({ port }) => (
   port.addEventListener('message', ev => (

--- a/tests/tests-source-map/package.json
+++ b/tests/tests-source-map/package.json
@@ -7,13 +7,13 @@
   },
   "dependencies": {
     "esmock": "file:..",
-    "@ava/typescript": "^4.0.0",
-    "@tsconfig/node14": "^1.0.3",
-    "@types/node": "^20.1.5",
-    "ava": "^5.2.0",
+    "@ava/typescript": "^4.1.0",
+    "@tsconfig/node16": "^16.1.0",
+    "@types/node": "^20.4.5",
+    "ava": "^5.3.1",
     "cross-env": "^7.0.3",
-    "rimraf": "^3.0.2",
-    "typescript": "^5.0.4"
+    "rimraf": "^5.0.1",
+    "typescript": "^5.1.6"
   },
   "scripts": {
     "test-metaresolve": "rimraf dist && tsc && cross-env \"NODE_OPTIONS=--experimental-import-meta-resolve --loader=esmock\" NODE_NO_WARNINGS=1 ava",

--- a/tests/tests-source-map/tsconfig.json
+++ b/tests/tests-source-map/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "@tsconfig/node14/tsconfig.json",
+    "extends": "@tsconfig/node16/tsconfig.json",
     "compilerOptions": {
         "module": "Node16",
         "moduleResolution": "Node16",


### PR DESCRIPTION
cc @koshic  @tommy-mitchell re https://github.com/iambumblehead/esmock/issues/215

this PR removes the hashbang line from the sources before prepending import expressions, then re-adds any hashbang line to the final result returned by the loader