### PR TITLE
Add failing test for #218

### DIFF
--- a/tests/local/usesModuleWithCJSDependency.js
+++ b/tests/local/usesModuleWithCJSDependency.js
@@ -1,0 +1,5 @@
+import meow from 'meow'
+
+const cli = meow('foo', { importMeta: import.meta, description: false })
+
+console.log(cli.help);

--- a/tests/local/usesModuleWithCJSDependency.js
+++ b/tests/local/usesModuleWithCJSDependency.js
@@ -2,4 +2,4 @@ import meow from 'meow'
 
 const cli = meow('foo', { importMeta: import.meta, description: false })
 
-console.log(cli.help);
+console.log(cli.help)

--- a/tests/package.json
+++ b/tests/package.json
@@ -15,13 +15,14 @@
     "#sub": "./local/subpath.js"
   },
   "dependencies": {
-    "pg": "^8.7.3",
+    "babelGeneratedDoubleDefault": "file:./local/babelGeneratedDoubleDefault",
     "eslint": "^8.12.0",
-    "sinon": "^12.0.1",
     "form-urlencoded": "^6.0.7",
-    "run-script-os": "^1.1.6",
+    "meow": "12.0.1",
     "npm-run-all": "^4.1.5",
-    "babelGeneratedDoubleDefault": "file:./local/babelGeneratedDoubleDefault"
+    "pg": "^8.7.3",
+    "run-script-os": "^1.1.6",
+    "sinon": "^12.0.1"
   },
   "scripts": {
     "mini": "cd .. && cd src && npx esbuild esmock.js --minify --bundle --allow-overwrite --platform=node --format=esm --outfile=esmock.js",

--- a/tests/tests-node/esmock.node.global.test.js
+++ b/tests/tests-node/esmock.node.global.test.js
@@ -74,4 +74,4 @@ test('should work when modules have CJS imports', async () => {
   })
 
   assert.deepEqual(logs, ['\nfoo\n'])
-});
+})

--- a/tests/tests-node/esmock.node.global.test.js
+++ b/tests/tests-node/esmock.node.global.test.js
@@ -63,3 +63,15 @@ test('should mock files with hashbangs', async () => {
 
   assert.deepEqual(logs, ['foo'])
 })
+
+test('should work when modules have CJS imports', async () => {
+  const logs = []
+
+  await esmock('../local/usesModuleWithCJSDependency.js', {}, {
+    import: {
+      console: { log: (...args) => logs.push(...args) }
+    }
+  })
+
+  assert.deepEqual(logs, ['\nfoo\n'])
+});


### PR DESCRIPTION
Ref: #218

Adds `meow@12.0.1` as a pinned dependency to `tests/package.json`. We could probably reproduce this with local files, but I added a dependency as it was faster to reproduce the error.