### PR TITLE
use nextLoad().format rather than context.format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # changelog
 
+ * 2.3.6 _Aug.07.2023_
+   * [resolve global mocking issues](https://github.com/iambumblehead/esmock/pull/224) when using mixed esm cjs import trees
  * 2.3.4 _Jul.30.2023_
    * [do not error when mocking commonjs](https://github.com/iambumblehead/esmock/pull/220) global values, found by @tommy-mitchell
  * 2.3.3 _Jul.28.2023_

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esmock",
   "type": "module",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "license": "ISC",
   "readmeFilename": "README.md",
   "description": "provides native ESM import and globals mocking for unit tests",

--- a/src/esmockLoader.js
+++ b/src/esmockLoader.js
@@ -138,7 +138,8 @@ const load = async (url, context, nextLoad) => {
   if (treeid) {
     const [specifier, importedNames] = parseImportsTree(treeidspec)
     if (importedNames && importedNames.length) {
-      const source = String((await nextLoad(url, context)).source)
+      const nextLoadRes = await nextLoad(url, context)
+      const source = String(nextLoadRes.source)
       const hbang = (source.match(hashbangRe) || [])[0] || ''
       const sourcesafe = hbang ? source.replace(hashbangRe, '') : source
       const importexpr = context.format === 'commonjs'
@@ -146,7 +147,7 @@ const load = async (url, context, nextLoad) => {
         : `import {${importedNames}} from '${specifier}';`
 
       return {
-        format: context.format === 'commonjs' ? 'commonjs' : 'module',
+        format: nextLoadRes.format,
         shortCircuit: true,
         responseURL: encodeURI(url),
         source: hbang + importexpr + sourcesafe

--- a/tests/local/usesModuleWithCJSDependency.ts
+++ b/tests/local/usesModuleWithCJSDependency.ts
@@ -1,0 +1,6 @@
+#!/usr/bin/env ts-node-esm
+import meow from 'meow'
+
+const cli = meow('foo', { importMeta: import.meta })
+
+export default () => console.log(cli.help)

--- a/tests/tests-nodets/esmock.node-ts.test.ts
+++ b/tests/tests-nodets/esmock.node-ts.test.ts
@@ -1,4 +1,4 @@
-import test from 'node:test'
+import test, { mock } from 'node:test'
 import assert from 'assert'
 import esmock from 'esmock'
 
@@ -11,4 +11,17 @@ test('should mock ts when using node-ts', { only: true }, async () => {
 
   assert.strictEqual(main.pathbasenamewrap(), 'hellow')
   assert.ok(true)
+})
+
+test('should mock import global at import tree w/ mixed esm cjs', async () => {
+  const consolelog = mock.fn()
+  const trigger = await esmock('../local/usesModuleWithCJSDependency.ts', {}, {
+    import: {
+      console: { log: consolelog }
+    }
+  })
+
+  trigger()
+  trigger()    
+  assert.strictEqual(consolelog.mock.calls.length, 2)
 })


### PR DESCRIPTION
re https://github.com/iambumblehead/esmock/pull/224 `context.format` is not always defined and `nextLoad().format` is always defined and using `nextLoad().format` allows the test to pass