### PR TITLE
add import json tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "plugins": [],
-  "ignorePatterns": ["dist"],
+  "ignorePatterns": ["importsJSONfile.js"],
   "extends": [
     "eslint:recommended",
     "plugin:markdown/recommended"    

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
  * 2.5.9 _Nov.11.2023_
    * [mock Array-type default export,](https://github.com/iambumblehead/esmock/pull/266) thanks @altearius
+   * [support json import mocking,](https://github.com/iambumblehead/esmock/pull/247) only working at node v21, see [node#49724](https://github.com/nodejs/node/issues/49724)
  * 2.5.8 _Oct.23.2023_
    * [catch yarn PnP exceptions](https://github.com/iambumblehead/esmock/pull/262) @koshic
  * 2.5.7 _Oct.20.2023_

--- a/src/esmockCache.js
+++ b/src/esmockCache.js
@@ -8,6 +8,13 @@ const esmockCache = {
   mockDefs: {}
 }
 
+const esmockModuleIdSourceSet = (keysource, source) => (
+  esmockPostMessage({ keysource, source }),
+  global.mockKeysSource[String(keysource)] = source)
+
+const esmockModuleIdSourceGet = keysource => (
+  global.mockKeysSource[String(keysource)])
+
 const esmockTreeIdSet = (key, keylong) => (
   esmockPostMessage({ key, keylong }),
   global.mockKeys[String(key)] = keylong)
@@ -31,7 +38,8 @@ Object.assign(global, {
   esmockCache,
   esmockCacheGet,
   esmockTreeIdGet,
-  mockKeys: global.mockKeys || {}
+  mockKeys: global.mockKeys || {},
+  mockKeysSource: global.mockKeysSource || {}
 })
 
 export {
@@ -40,6 +48,8 @@ export {
   esmockCacheGet,
   esmockTreeIdSet,
   esmockTreeIdGet,
+  esmockModuleIdSourceSet,
+  esmockModuleIdSourceGet,
   esmockCacheResolvedPathIsESMGet,
   esmockCacheResolvedPathIsESMSet
 }

--- a/src/esmockLoader.js
+++ b/src/esmockLoader.js
@@ -20,7 +20,6 @@ const esmkModuleIdRe = /esmkModuleId=([^&]*)/
 const esmkIdRe = /\?esmk=\d*/
 const exportNamesRe = /.*exportNames=(.*)/
 const withHashRe = /.*#-#/
-const isJSONExtnRe = /\.json$/i
 const isesmRe = /isesm=true/
 const isnotfoundRe = /isfound=false/
 const iscommonjsmoduleRe = /^(commonjs|module)$/

--- a/tests/local/example.json
+++ b/tests/local/example.json
@@ -1,0 +1,1 @@
+{ "example": "json" }

--- a/tests/local/importsJSONfile.js
+++ b/tests/local/importsJSONfile.js
@@ -1,0 +1,5 @@
+import JSONobj from './example.json' assert { type: 'json' };
+
+export {
+  JSONobj
+}

--- a/tests/tests-node/esmock.node.test.js
+++ b/tests/tests-node/esmock.node.test.js
@@ -557,6 +557,9 @@ test('should mock imported json', async () => {
       }
     })
 
+  if (/^(18|20)$/.test(process.versions.node.split('.')[0]))
+    return assert.ok(true)
+  
   assert.strictEqual(
     Object.keys(importsJSON.JSONobj).sort().join(), 'example,test-example')
   assert.strictEqual(importsJSON.JSONobj['test-example'], 'test-json-a')
@@ -571,6 +574,9 @@ test('should mock imported json (strict)', async () => {
       }
     })
 
+  if (/^(18|20)$/.test(process.versions.node.split('.')[0]))
+    return assert.ok(true)
+  
   assert.strictEqual(
     Object.keys(importsJSON.JSONobj).sort().join(), 'test-example')
   assert.strictEqual(importsJSON.JSONobj['test-example'], 'test-json-b')

--- a/tests/tests-node/esmock.node.test.js
+++ b/tests/tests-node/esmock.node.test.js
@@ -557,8 +557,8 @@ test('should mock imported json', async () => {
       }
     })
 
-  //if (/^(18|20)$/.test(process.versions.node.split('.')[0]))
-  //  return assert.ok(true)
+  if (/^(18|20)$/.test(process.versions.node.split('.')[0]))
+    return assert.ok(true)
   
   assert.strictEqual(
     Object.keys(importsJSON.JSONobj).sort().join(), 'example,test-example')
@@ -574,8 +574,8 @@ test('should mock imported json (strict)', async () => {
       }
     })
 
-  //if (/^(18|20)$/.test(process.versions.node.split('.')[0]))
-  //  return assert.ok(true)
+  if (/^(18|20)$/.test(process.versions.node.split('.')[0]))
+    return assert.ok(true)
   
   assert.strictEqual(
     Object.keys(importsJSON.JSONobj).sort().join(), 'test-example')

--- a/tests/tests-node/esmock.node.test.js
+++ b/tests/tests-node/esmock.node.test.js
@@ -548,3 +548,32 @@ test('should mock an exported array', async () => {
 
   assert.deepStrictEqual(importsArray(), ['mocked'])
 })
+
+test('should mock imported json', async () => {
+  const importsJSON = await esmock(
+    '../local/importsJSONfile.js', {
+      '../local/example.json': {
+        'test-example': 'test-json'
+      }
+    })
+
+  assert.strictEqual(
+    Object.keys(importsJSON.JSONobj).sort().join(), 'example,test-example')
+  assert.strictEqual(importsJSON.JSONobj['test-example'], 'test-json')
+  assert.strictEqual(importsJSON.JSONobj['example'], 'json')
+})
+/*
+test('should mock imported json (strict)', async () => {
+  const importsJSON = await esmock.strict(
+    '../local/importsJSONfile.js', {
+      '../local/example.json': {
+        'test-example': 'test-json'
+      }
+    })
+
+  assert.strictEqual(
+    Object.keys(importsJSON.JSONobj).sort().join(), 'test-example')
+  assert.strictEqual(importsJSON.JSONobj['test-example'], 'test-json')
+})
+*/
+

--- a/tests/tests-node/esmock.node.test.js
+++ b/tests/tests-node/esmock.node.test.js
@@ -553,27 +553,25 @@ test('should mock imported json', async () => {
   const importsJSON = await esmock(
     '../local/importsJSONfile.js', {
       '../local/example.json': {
-        'test-example': 'test-json'
+        'test-example': 'test-json-a'
       }
     })
 
   assert.strictEqual(
     Object.keys(importsJSON.JSONobj).sort().join(), 'example,test-example')
-  assert.strictEqual(importsJSON.JSONobj['test-example'], 'test-json')
+  assert.strictEqual(importsJSON.JSONobj['test-example'], 'test-json-a')
   assert.strictEqual(importsJSON.JSONobj['example'], 'json')
 })
-/*
+
 test('should mock imported json (strict)', async () => {
   const importsJSON = await esmock.strict(
     '../local/importsJSONfile.js', {
       '../local/example.json': {
-        'test-example': 'test-json'
+        'test-example': 'test-json-b'
       }
     })
 
   assert.strictEqual(
     Object.keys(importsJSON.JSONobj).sort().join(), 'test-example')
-  assert.strictEqual(importsJSON.JSONobj['test-example'], 'test-json')
+  assert.strictEqual(importsJSON.JSONobj['test-example'], 'test-json-b')
 })
-*/
-

--- a/tests/tests-node/esmock.node.test.js
+++ b/tests/tests-node/esmock.node.test.js
@@ -557,8 +557,8 @@ test('should mock imported json', async () => {
       }
     })
 
-  if (/^(18|20)$/.test(process.versions.node.split('.')[0]))
-    return assert.ok(true)
+  //if (/^(18|20)$/.test(process.versions.node.split('.')[0]))
+  //  return assert.ok(true)
   
   assert.strictEqual(
     Object.keys(importsJSON.JSONobj).sort().join(), 'example,test-example')
@@ -574,8 +574,8 @@ test('should mock imported json (strict)', async () => {
       }
     })
 
-  if (/^(18|20)$/.test(process.versions.node.split('.')[0]))
-    return assert.ok(true)
+  //if (/^(18|20)$/.test(process.versions.node.split('.')[0]))
+  //  return assert.ok(true)
   
   assert.strictEqual(
     Object.keys(importsJSON.JSONobj).sort().join(), 'test-example')


### PR DESCRIPTION
re https://github.com/iambumblehead/esmock/issues/246

On first implementation, there is an issue. When multiple tests are added around this feature, they fail. Nodejs returns only the first-resolved json result to many callers., even though each mocked-json is requested through its own unique uri.