### PR TITLE
remove condition preventing core moduleIds from resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # changelog
 
  * 2.5.4 _Oct.13.2023_
-   * [remove condition](https://github.com/iambumblehead/esmock/pull/253) to not-call resolver with builtin moduleId
+   * [remove condition](https://github.com/iambumblehead/esmock/pull/252) to not-call resolver with builtin moduleId
  * 2.5.3 _Oct.12.2023_
    * [update resolver](https://github.com/iambumblehead/esmock/pull/250) to latest version, slightly faster with fewer loops
    * [add support for resolver](https://github.com/iambumblehead/esmock/pull/251) configuration option

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # changelog
 
+ * 2.5.4 _Oct.13.2023_
+   * [remove condition](https://github.com/iambumblehead/esmock/pull/253) to not-call resolver with builtin moduleId
  * 2.5.3 _Oct.12.2023_
    * [update resolver](https://github.com/iambumblehead/esmock/pull/250) to latest version, slightly faster with fewer loops
    * [add support for resolver](https://github.com/iambumblehead/esmock/pull/251) configuration option

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esmock",
   "type": "module",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "license": "ISC",
   "readmeFilename": "README.md",
   "description": "provides native ESM import and globals mocking for unit tests",

--- a/src/esmockModule.js
+++ b/src/esmockModule.js
@@ -18,8 +18,6 @@ const nextId = ((id = 0) => () => ++id)()
 const objProto = Object.getPrototypeOf({})
 const isPlainObj = o => Object.getPrototypeOf(o) === objProto
 const iscoremodule = resolvewith.iscoremodule
-const protocolNodeRe = /^node:/
-const addprotocolnode = p => protocolNodeRe.test(p) ? p : `node:${p}`
 
 // assigning the object to its own prototypal inheritor can error, eg
 //   'Cannot assign to read only property \'F_OK\' of object \'#<Object>\''
@@ -111,9 +109,6 @@ const esmockModuleCreate = async (treeid, def, id, fileURL, opt) => {
   return mockModuleKey
 }
 
-const esmockResolve = (id, parent, opt) => (
-  iscoremodule(id) ? addprotocolnode(id) : opt.resolver(id, parent))
-
 const esmockModuleId = async (parent, treeid, defs, ids, opt, mocks, id) => {
   ids = ids || Object.keys(defs)
   id = ids[0]
@@ -121,7 +116,7 @@ const esmockModuleId = async (parent, treeid, defs, ids, opt, mocks, id) => {
 
   if (!id) return mocks
 
-  const fileURL = esmockResolve(id, parent, opt)
+  const fileURL = opt.resolver(id, parent)
   if (!fileURL && opt.isModuleNotFoundError !== false && id !== 'import')
     throw esmockErr.errModuleIdNotFound(id, parent)
 
@@ -131,7 +126,7 @@ const esmockModuleId = async (parent, treeid, defs, ids, opt, mocks, id) => {
 }
 
 const esmockModule = async (moduleId, parent, defs, gdefs, opt) => {
-  const moduleFileURL = esmockResolve(moduleId, parent, opt)
+  const moduleFileURL = opt.resolver(moduleId, parent)
   if (!moduleFileURL)
     throw esmockErr.errModuleIdNotFound(moduleId, parent)
 

--- a/tests/tests-node/esmock.node.resolver-custom.test.js
+++ b/tests/tests-node/esmock.node.resolver-custom.test.js
@@ -4,18 +4,21 @@ import module from 'node:module'
 import esmock from 'esmock'
 
 function resolverCustom (moduleId, parent) {
-  parent = parent.replace(/\/tests\/.*$/, '/tests/tests-node/')
-
   // This logic looks unusual because of constraints here. This function must:
   //  * must work at windows, where path.join and path.resolve cause issues
   //  * must be string-serializable, no external funcions
   //  * must resolve these moduleIds to corresponding, existing filepaths
   //    * '../local/customResolverParent.js',
   //    * 'RESOLVECUSTOM/
+  if (/(node:)?path/.test(moduleId))
+    return 'node:path'
+
   return (
-    /RESOLVECUSTOM$/.test(moduleId)
-      ? parent + '../local/customResolverChild.js'
-      : parent + moduleId
+    parent.replace(/\/tests\/.*$/, '/tests/tests-node/') + (
+      /RESOLVECUSTOM$/.test(moduleId)
+        ? '../local/customResolverChild.js'
+        : moduleId
+    )
   ).replace(/\/tests-node\/\.\./, '')
 }
 


### PR DESCRIPTION
Per [the resolver spec,](https://nodejs.org/api/esm.html#resolution-algorithm-specification) the resolver should handle builtin module names
> PACKAGE_RESOLVE(packageSpecifier, parentURL)
> ...
>   3. If packageSpecifier is a Node.js builtin module name, then
>   .   1. Return the string "node:" concatenated with packageSpecifier.

This PR removes a condition that prevented the resolver from being called with builtin moduleIds and
 * slightly simplifies esmock, esmock calls the resolver with any moduleId
 * anticipates that the resolver is spec compliant and handles builtin moduleIds