### PR TITLE
increment resolvewithplus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # changelog
 
+ * 2.5.6 _Oct.15.2023_
+   * [update resolver](https://github.com/iambumblehead/esmock/pull/256) to latest version, [resolves a resolution error](https://github.com/iambumblehead/resolvewithplus/releases/tag/v2.0.9) that seems to have been introduced by a previous update from the past week.
  * 2.5.5 _Oct.14.2023_
    * [support yarn PnP](https://github.com/iambumblehead/esmock/pull/255) @koshic
  * 2.5.4 _Oct.13.2023_

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esmock",
   "type": "module",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "license": "ISC",
   "readmeFilename": "README.md",
   "description": "provides native ESM import and globals mocking for unit tests",
@@ -60,7 +60,7 @@
     "node": ">=14.16.0"
   },
   "dependencies": {
-    "resolvewithplus": "^2.0.8"
+    "resolvewithplus": "^2.0.9"
   },
   "devDependencies": {
     "c8": "^8.0.1",


### PR DESCRIPTION
[update resolver](https://github.com/iambumblehead/esmock/pull/256) to latest version, [resolves a resolution error](https://github.com/iambumblehead/resolvewithplus/releases/tag/v2.0.9) that seems to have been introduced by a previous update from the past week.