### PR TITLE
catch exceptions generated by pnpapi

### DIFF
--- a/src/pnpResolver.js
+++ b/src/pnpResolver.js
@@ -12,7 +12,10 @@ export default pnpapi && ((id, parent) => {
     return null
   }
 
-  const path = pnpapi.resolveRequest(id, parent)
+  let path = null
+  try {
+    path = pnpapi.resolveRequest(id, parent)
+  } catch {}
 
   return path !== null ? pathToFileURL(path).href : null
 })


### PR DESCRIPTION
When we try to mock non-existent files, Yarn PnP throws an exception in `pnpapi.resolveRequest`. It's safe to ignore them and return null, 'module not resolved, sorry'.