### PR TITLE
Add unit testing demonstrating failure to mock an array

### DIFF
--- a/tests/local/exportsArray.js
+++ b/tests/local/exportsArray.js
@@ -1,0 +1,7 @@
+const exportedArray = [
+  { name: "1" },
+  { name: "2" },
+  { name: "3" }
+]
+
+export default exportedArray

--- a/tests/local/importsArray.js
+++ b/tests/local/importsArray.js
@@ -1,0 +1,5 @@
+import exportedArray from "./exportsArray.js"
+
+export default function importsArray () {
+  return exportedArray
+}

--- a/tests/tests-node/esmock.node.test.js
+++ b/tests/tests-node/esmock.node.test.js
@@ -536,3 +536,15 @@ test('should mock scoped package, @aws-sdk/client-s3 (deep)', async () => {
 
   assert.strictEqual(scopedClientS3.mocked, 'mock client')
 })
+
+test('should mock an exported array', async () => {
+  const mockedArray = ['mocked']
+
+  const importsArray = await esmock(
+    '../local/importsArray.js', {
+      '../local/exportsArray.js': mockedArray
+    }
+  )
+
+  assert.deepStrictEqual(importsArray(), ['mocked'])
+})


### PR DESCRIPTION
In accordance with the contributor guidelines, this PR introduces a failing unit test.

The unit test currently fails on Node v20.9.0 with the following message:

```
✖ should mock an exported array (4.967011ms)
  SyntaxError [Error]: Unexpected number
      at ModuleLoader.moduleStrategy (node:internal/modules/esm/translators:118:18)
      at callTranslator (node:internal/modules/esm/loader:273:14)
      at ModuleLoader.moduleProvider (node:internal/modules/esm/loader:278:30)
ERROR: "test:node18-test-node" exited with 1.
```