### PR TITLE
typings: make MockFunction generic

### DIFF
--- a/src/esmock.d.ts
+++ b/src/esmock.d.ts
@@ -22,19 +22,19 @@ type MockFunction = {
    * @param opts
    * @returns The mocked import-tree result of "import({@link modulePath})"
    */
-  (
+  <T>(
     modulePath: string,
     parent: string,
     defs?: MockMap,
     gdefs?: MockMap,
     opts?: Options
-  ): any,
-  (
+  ): Promise<T>,
+  <T>(
     modulePath: string,
     defs?: MockMap,
     gdefs?: MockMap,
     opts?: Options
-  ): any
+  ): Promise<T>
 }
 
 /**

--- a/src/esmock.d.ts
+++ b/src/esmock.d.ts
@@ -22,14 +22,14 @@ type MockFunction = {
    * @param opts
    * @returns The mocked import-tree result of "import({@link modulePath})"
    */
-  <T>(
+  <T = any>(
     modulePath: string,
     parent: string,
     defs?: MockMap,
     gdefs?: MockMap,
     opts?: Options
   ): Promise<T>,
-  <T>(
+  <T = any>(
     modulePath: string,
     defs?: MockMap,
     gdefs?: MockMap,


### PR DESCRIPTION
this allows esmock to be used in a more convenient way in typescript setups

```
import esmock from 'esmock';
import type * as moduleUnderTest from './moduleUnderTest.js';

const { func } = await esmock<typeof moduleUnderTest>(
  './moduleUnderTest.js',
  import.meta.url,
  {
    //...
  },
);
const actual = await func();
```