### PR TITLE
Enrich the docs when it comes to types

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,8 @@ test('full import tree mocks —third param', async () => {
   assert.equal(getFile(), 'returned to 🌲 every caller in the tree')
 })
 
-import type * as utilsType from '../src/utils.js/';
 test('allows you to specify the type of returned exports', async () => {
-  const { multiplyNumbers } = await esmock<typeof utilsType>(
+  const { multiplyNumbers } = await esmock<typeof import('../src/utils.js')>(
     '../src/utils.js', {
     multiplyNumbers: (numbers: number[]): number => numbers.reduce((acc, current) => acc *= current, 1),
   })

--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ test('full import tree mocks —third param', async () => {
   assert.equal(getFile(), 'returned to 🌲 every caller in the tree')
 })
 
+import type * as utilsType from '../src/utils.js/';
+test('allows you to specify the type of returned exports', async () => {
+  const { multiplyNumbers } = await esmock<typeof utilsType>(
+    '../src/utils.js', {
+    multiplyNumbers: (numbers: number[]): number => numbers.reduce((acc, current) => acc *= current, 1),
+  })
+
+  assert.equal(multiplyNumbers([1, 2, 3]), 6)
+})
+
 test('mock fetch, Date, setTimeout and any globals', async () => {
   // https://github.com/iambumblehead/esmock/wiki#call-esmock-globals
   const { userCount } = await esmock('../Users.js', {


### PR DESCRIPTION
I noticed that after the addition of https://github.com/iambumblehead/esmock/pull/267, there is nothing in the docs to show that `esmock` is now type generic.