### PR TITLE
update README to work with markdown lint plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # changelog
 
+ * 2.6.1 _???.??.2023_
+   * [update README to work w/ eslint-plugin-markdown](https://github.com/iambumblehead/esmock/pull/275)
  * 2.6.0 _Nov.07.2023_
    * [typings: make MockFunction generic,](https://github.com/iambumblehead/esmock/pull/267) thanks @uwinkelvos
  * 2.5.9 _Nov.01.2023_

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 _**Note: For versions of node prior to v20.6.0,** "--loader" command line arguments must be used with `esmock` as demonstrated [in the wiki.][4] Current versions of node do not require "--loader"._
 
 `esmock` has the below signature
-``` javascript
+```js
 await esmock(
   './to/module.js', // path to target module being tested
   { ...childmocks }, // mock definitions imported by target module
@@ -22,7 +22,7 @@ await esmock(
 ```
 
 `esmock` examples
-``` javascript
+```js
 import test from 'node:test'
 import assert from 'node:assert'
 import esmock from 'esmock'


### PR DESCRIPTION
This PR updates the README so that it will be linted with the markdown lint plugin.

related links,
 * https://github.com/eslint/eslint-plugin-markdown/issues/227
 * https://github.com/iambumblehead/esmock/pull/273