### PR TITLE
Repro express failing test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # changelog
 
- * 2.6.1 _Jan.14.2023_
+ * 2.6.2 _Jan.14.2023_
+   * [remove reserved keywords](https://github.com/iambumblehead/esmock/pull/287) from export names lists, allows express to be mocked, thanks @lcapel
+ * 2.6.1 _Jan.13.2023_
    * [update ci job to use checkout v4](https://github.com/iambumblehead/esmock/pull/279)
    * [update README to work w/ eslint-plugin-markdown](https://github.com/iambumblehead/esmock/pull/275)
    * [update eslint](https://github.com/iambumblehead/esmock/pull/276) disallow trailing whitespace

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esmock",
   "type": "module",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "license": "ISC",
   "readmeFilename": "README.md",
   "description": "provides native ESM import and globals mocking for unit tests",

--- a/src/esmockModule.js
+++ b/src/esmockModule.js
@@ -116,7 +116,8 @@ const esmockModuleCreate = async (treeid, def, id, fileURL, opt) => {
     'isfound=' + Boolean(fileURL),
     'isesm=' + esmockModuleIsESM(fileURL),
     'exportNames=' + Object.keys(def).sort().join()
-      .replace(reservedKeywordsFoundInWild, '')
+      .replace(reservedKeywordsFoundInWild, a => (
+        a.startsWith(',') && a.endsWith(',') ? ',' : ''))
   ].join('&')
 
   if (isJSONExtnRe.test(fileURL)) {

--- a/src/esmockModule.js
+++ b/src/esmockModule.js
@@ -22,6 +22,10 @@ const isPlainObj = o => Object.getPrototypeOf(o) === objProto
 const iscoremodule = resolvewith.iscoremodule
 const isJSONExtnRe = /\.json$/i
 
+// https://github.com/iambumblehead/esmock/issues/284
+// older applications may export names that are reserved in newer runtimes
+const reservedKeywordsFoundInWild = /(^|,)static($|,)/g
+
 // assigning the object to its own prototypal inheritor can error, eg
 //   'Cannot assign to read only property \'F_OK\' of object \'#<Object>\''
 //
@@ -112,6 +116,7 @@ const esmockModuleCreate = async (treeid, def, id, fileURL, opt) => {
     'isfound=' + Boolean(fileURL),
     'isesm=' + esmockModuleIsESM(fileURL),
     'exportNames=' + Object.keys(def).sort().join()
+      .replace(reservedKeywordsFoundInWild, '')
   ].join('&')
 
   if (isJSONExtnRe.test(fileURL)) {

--- a/tests/local/usesExpress.js
+++ b/tests/local/usesExpress.js
@@ -1,0 +1,11 @@
+import express from 'express'
+
+export default () => {
+  const router = express.Router()
+
+  router.get('/route', (req, res, next) => {
+    return [req, res, next]
+  })
+
+  return router
+}

--- a/tests/package.json
+++ b/tests/package.json
@@ -15,6 +15,7 @@
     "#sub": "./local/subpath.js"
   },
   "dependencies": {
+    "express": "^4.18.2",
     "@aws-sdk/client-s3": "^3.408.0",
     "babelGeneratedDoubleDefault": "file:./local/babelGeneratedDoubleDefault",
     "eslint": "^8.12.0",

--- a/tests/tests-node/esmock.node.test.js
+++ b/tests/tests-node/esmock.node.test.js
@@ -603,3 +603,24 @@ test('mocks await import node:fs/promises (global)', async () => {
   assert.deepStrictEqual(
     await main.importFSPromisesReadDir(), ['mock', 'global'])
 })
+
+// https://github.com/iambumblehead/esmock/issues/284
+// older applications may export names that are reserved in newer runtimes
+//
+// express exports this...
+// ```js
+// exports.static = require('serve-static');
+// ```
+test('mocks express, exports disallowed reserved keyword "static"', async () => {
+  const calls = []
+
+  assert.ok(await esmock('../local/usesExpress.js', import.meta.url, {
+    express: {
+      Router: {
+        get: (path, fn) => {
+          calls.push([path, fn])
+        }
+      }
+    }
+  }))
+})

--- a/tests/tests-node/esmock.node.test.js
+++ b/tests/tests-node/esmock.node.test.js
@@ -611,7 +611,7 @@ test('mocks await import node:fs/promises (global)', async () => {
 // ```js
 // exports.static = require('serve-static');
 // ```
-test('mocks express, exports disallowed reserved keyword "static"', async () => {
+test('mocks express, exports disallowed keyword "static"', async () => {
   const calls = []
 
   assert.ok(await esmock('../local/usesExpress.js', import.meta.url, {


### PR DESCRIPTION
closes https://github.com/iambumblehead/esmock/issues/284

this PR resolved an error that occurs when mocking older sources that export names reserved in newer runtimes
```diff
diff --git a/src/esmockModule.js b/src/esmockModule.js
index 31ade8f..3f28ca0 100644
--- a/src/esmockModule.js
+++ b/src/esmockModule.js
@@ -22,6 +22,10 @@ const isPlainObj = o => Object.getPrototypeOf(o) === objProto
 const iscoremodule = resolvewith.iscoremodule
 const isJSONExtnRe = /\.json$/i
 
+// https://github.com/iambumblehead/esmock/issues/284
+// older applications may export names that are reserved in newer runtimes
+const reservedKeywordsFoundInWild = /(^|,)static($|,)/g
+
 // assigning the object to its own prototypal inheritor can error, eg
 //   'Cannot assign to read only property \'F_OK\' of object \'#<Object>\''
 //
@@ -112,6 +116,7 @@ const esmockModuleCreate = async (treeid, def, id, fileURL, opt) => {
     'isfound=' + Boolean(fileURL),
     'isesm=' + esmockModuleIsESM(fileURL),
     'exportNames=' + Object.keys(def).sort().join()
+      .replace(reservedKeywordsFoundInWild, '')
   ].join('&')
 
   if (isJSONExtnRe.test(fileURL)) {
```

cc @koshic @lcapel